### PR TITLE
Correct variable in ebi toml

### DIFF
--- a/backend-server/config/sources-ebi.toml
+++ b/backend-server/config/sources-ebi.toml
@@ -1,3 +1,3 @@
 [source]
 driver = "file"
-path = "/usr/data/newsite/dev/genome_browser/s3-data"
+root = "/usr/data/newsite/dev/genome_browser/s3-data"


### PR DESCRIPTION
The code here https://github.com/Ensembl/ensembl-dauphin-style-compiler/blob/master/backend-server/app/model/datalocator.py#L107 is expecting root not path