### PR TITLE
Location coordinate system should start at 1 rather than 0

### DIFF
--- a/peregrine-ensembl/src/lib.rs
+++ b/peregrine-ensembl/src/lib.rs
@@ -263,7 +263,7 @@ impl GenomeBrowser {
 
                                     args.set(1,JsValue::from(js_throw(JsValue::from_serde(&LocationData {
                                         stick: stick.to_string(),
-                                        start: *start as f64,
+                                        start: (1.0_f64).max(*start as f64),
                                         end: *end as f64
                                     }))));
 
@@ -275,7 +275,7 @@ impl GenomeBrowser {
 
                                     args.set(1,JsValue::from(js_throw(JsValue::from_serde(&LocationData {
                                         stick: stick.to_string(),
-                                        start: *start as f64,
+                                        start: (1.0_f64).max(*start as f64),
                                         end: *end as f64
                                     }))));
                                     


### PR DESCRIPTION
## Description
Ensembl coordinate system starts at 1; therefore, in messages about genome browser location, the smallest start coordinate should be 1 rather than 0.

The client is sensitive to this. When the genome browser was reporting its start coordinate as 0, we were hiding the location indicator, like so:

https://user-images.githubusercontent.com/6834224/197566475-ad7f4548-2d83-480a-a1b7-e27954858cc0.mov

Checked in development with the applied fix:

https://user-images.githubusercontent.com/6834224/197566571-e307f09b-c5e1-4ea8-9dfe-07ab4ae1cfd4.mov

## Not checked
- Did not check for any message cycles. Will it be possible that, when browser chrome will be reflecting into genome browser coordinates 1--n, the genome browser will be trying to navigate to 0--n, but messaging to the client that the location is 1--n, as defined in this PR? I don't expect this to create an infinite loop; but one can never be sure.
- Genome browser is a bit slow to report the target location (the one that will be used to update the url) when it is start--chromosome_length of the whole chromosome. Is this expected?

## Questions
- The PR still keeps the location start and end coordinates as f64. Should I cast them to i32 instead? Or i64, since the maximum value of i32 is in the vicinity of 2 billion? Will Rust object?
- Should this PR be made against the staging the master branch?