### PR TITLE
Update group ids in the comments

### DIFF
--- a/backend-server/egs-data/egs/v16/variant/variant-common.eard
+++ b/backend-server/egs-data/egs/v16/variant/variant-common.eard
@@ -12,11 +12,11 @@ function summary_leaf(track_name,suffix) {
 export function variant_colours() {
     [
         colour!("#fff"),    // 0 = white
-        colour!("#EB768A"), // 5 = dark-pink
-        colour!("#f8c041"), // 4 = dark-yellow
+        colour!("#EB768A"), // 1 = dark-pink
+        colour!("#f8c041"), // 2 = dark-yellow
         colour!("#84fa3a"), // 3 = lime
-        colour!("#327c89"), // 2 = teal
-        colour!("#96d0c9")  // 1 = duckegg-blue
+        colour!("#327c89"), // 4 = teal
+        colour!("#96d0c9")  // 5 = duckegg-blue
     ]
 }
 


### PR DESCRIPTION
Group id colours have been updated in one of the previous commits, this PR updates the comments to reflect that change.
