### PR TITLE
Add a new track for future regulation development, plus docs

### DIFF
--- a/backend-server/build-begs.sh
+++ b/backend-server/build-begs.sh
@@ -15,4 +15,5 @@ eard-compiler \
     -c $SRC/v16/gene/focus-zoomed-transcript.eard -c $SRC/v16/other/focus-region.eard \
     -c $SRC/v16/variant/focus-variant.eard -c $SRC/v16/variant/focus-variant-summary.eard \
     -c $SRC/v16/variant/focus-variant-dots.eard \
+    -c $SRC/v16//regulation/regulation.eard \
     -o $DST/render16.eardo

--- a/backend-server/config/boot-tracks/boot-tracks-16.toml
+++ b/backend-server/config/boot-tracks/boot-tracks-16.toml
@@ -257,6 +257,17 @@ triggers = [["track","focus","item","variant"]]
 focus-variant = ["track","focus","item","variant"]
 
 #
+# Regulation
+#
+[track.regulation]
+include = ["general"]
+scales = [1,100,1]
+triggers = [["track","regulation"]]
+
+[track.regulation.settings]
+name = ["track","regulation","name"]
+
+#
 # Contigs and Sequences
 #
 

--- a/backend-server/egs-data/egs/v16/regulation/regulation.eard
+++ b/backend-server/egs-data/egs/v16/regulation/regulation.eard
@@ -1,0 +1,58 @@
+program "ensembl-webteam/core" "regulation" 1;
+refer "libperegrine";
+refer "libeoe";
+include "../common/track-common.eard";
+include "../common/track-style.eard";
+
+/* Setup styles */
+track_styles();
+
+style!("""
+    tracks/track/regulation/ {
+        min-height: 100;
+        priority: 990;
+        report: "track;switch-id=regulation";
+    }
+""");
+
+draw_track_name("REGULATION","name",leaf("tracks/track/regulation/title/content"));
+
+/* Just fooling around */
+print("hello world!");
+
+
+
+
+let line_paint = paint_hollow(colour!("#d0d0d0"),1);
+let leaf = leaf("tracks/track/regulation/main/background/content");
+rectangle(coord([0],[60],[0]),coord([1],[60],[0]),line_paint,[leaf,...]);
+
+
+let test_leaf = leaf("tracks/track/regulation/main/background/content");
+let paint = paint_solid(colour!("#d0d0d0"));
+
+rectangle(
+  coord([0],[0],[0]),
+  coord([1],[1],[1]),
+  paint,
+  [test_leaf, ...]
+);
+
+let test_leaf = leaf("tracks/track/regulation/main/main/content");
+rectangle(
+  coord([32357710],[5],[5]),
+  coord([32357730],[10],[10]),
+  paint,
+  [test_leaf,...]
+);
+
+
+let name_text_size = 12;
+let name_text_colour = colour!("black");
+let pen = pen(
+  "'IBM Plex Mono', sans-serif",
+  name_text_size,
+  [name_text_colour,...],
+  [colour!("white"),...]
+);
+text(coord([32357710],[20],[20]),pen,["Some text please?"],[test_leaf,...]);

--- a/doc/registering-new-track.md
+++ b/doc/registering-new-track.md
@@ -1,0 +1,128 @@
+# Registering a new track
+Below are requirements to register a new track through the traditional Python channel.
+
+## Add the track to the track manifest
+Genome browser needs to be informed that a track exists. Currently, this is done statically, by adding track data to a toml file. For version 16, this file is `backend-server/config/boot-tracks/boot-tracks-16.toml`.
+
+### Minimal required track metadata
+Track declaration must include:
+- Track identifier (name of the eard program that draws the track)
+- The scales at which the track is displayed; formatted as `[start_scale, end_scale, step_for_redraw]`
+- Triggers to show/hide the track
+
+Example: for a track that is drawn by program `new-track`, which we want to draw at all scales, and want to instruct the genome browser to recalculate it at every scale, the metadata block will be:
+
+```
+[track.new-track] # set up an internal tree node, in this case for triggering an eard program "new-track"
+include = ["general"] # set program name prefix/suffix (imported from another toml at line 2)
+scales = [1,100,1] # rerun the program at every zoom level between 1-100
+triggers = [["track","new-track"]] # set a trigger for UI to run the program
+```
+
+CAUTION: the smaller the third parameter in the `scales` array, the more often genome browser will redraw the track, the more compute-intensive the track becomes. The larger the step, the better for performance.
+
+> DAN'S WISDOM: Tracks only make sense at certain scales. A scale is approximately 2^n base-pairs per screen (the exact position of the changeover depends on a number of external factors). So scale "20" means "around 1,000,000 bp on the screen", whereas scale "10" means around 1,000, and scale "5" means only around 32 bp on the screen. start and end are inclusive.
+> Step is a complex parameter which probably shouldn't be in the payload but set by the program (but this isn't possible right now). If the step is `1` then at each scale (corresponding to a factor of two) then the program is rerun. However, for efficiency, the script can only be rerun every step scales. If a script has enough, precise-enough data for all scales this saves a lot of computation. The value of step should be on the advice of the script writer.
+
+### Track settings metadata
+A track will likely have settings configurable at runtime through commands sent to the genome browser. These should be registered in the boot manifest as well. For example, a declaration that the track with an id of `new-track` responds to the `name` setting, will look like this:
+
+```
+[track.new-track.settings]
+name = ["track","new-track","name"]
+```
+
+The above attaches a setting called `name` to a subnode of `new-track` and wires it to a switch `["track","new-track","name"]`.
+With that, the web client can assign a value to the switch (e.g. set it to `true`, see below), the eard program `new-track` can then read this value from setting `name` and react to it (e.g. draw a label in the track).
+
+### Problems with the approach
+- The track manifest is static. Currently, it lists information about all available tracks. This will not be sustainable going forward. Expect the instructions above to change.
+
+
+## Add a program for drawing the track (or use an existing one)
+Track drawing programs are written in a special domain-specific language and saved as `.eard` files. A drawing program can be split into multiple files; but the entry point into a program will be the file with a program declaration in the top.
+
+Example:
+```
+program "ensembl-webteam/core" "test-drawing-program" 1;
+```
+
+> DAN'S WISDOM: Every eard script begins with a program line. This program line names a program. The name is used by every other part of the genome browser code (for example the track payloads) to refer to the script (in order to find it and to run it at the appropriate time). The name has three parts. The first part is a string which describes a set of people or a project which should have their act together to name things consistently. The second part is the name itself. The third is a version. The parts of the name are always processed together and the code doesn't break into the three parts: it always treats them as a unit. They're there to help you be consistent. There's no need to increment a version with every fix or change: it is there for if you want two versions to coexist in the system concurrently.
+> There are two ways of including another file in eard which differ only in how they go about finding the file. `refer` is for internal stuff -- library headers, etc -- and are conventional names for things buried deep inside the compiler. The docs for a function in the standard library it will tell you what you need to add to the top of your file. On the other hand, `include` is for files you write yourself, relative to the current file. This is useful for writing helper functions/procedures for tracks which share some visual element, or for data endpoints which have a lot in common.
+
+### Example of a minimal viable program
+Suppose a new program is created in `backend-server/egs-data/egs/v16/new-track/new-track.eard`. It will include its id in the track summary report; will be able to display its name; will put a horizontal line and a rectangle on the screen, and will print a message to web browser console.
+
+```
+program "ensembl-webteam/core" "new-track" 1;
+refer "libperegrine";
+refer "libeoe";
+include "../common/track-common.eard";
+include "../common/track-style.eard";
+
+/* 
+ * Setup styles.
+ * First, we are enabling common track styles, and then adding some custom styles for new track.
+ * Note that the instruction to report track id in the track summary is part of the styles.
+ */
+/*  */
+track_styles();
+
+style!("""
+    tracks/track/new-track/ {
+        min-height: 100;
+        priority: 990;
+        report: "track;switch-id=new-track";
+    }
+""");
+
+/* Make sure the name of the track can be printed */
+draw_track_name("NEW TRACK","name",leaf("tracks/track/new-track/title/content"));
+
+/* 
+ * Even if you messed up the drawing code and can't see anything on the screen,
+ * you can at least print stuff to the console to make sure your program is running
+ */
+print("hello world!");
+
+
+/* 
+ * Draw a 1-pixel-high rectangle across the whole viewport
+ */
+let test_leaf = leaf("tracks/track/new-track/main/background/content");
+let paint = paint_solid(colour!("#d0d0d0"));
+
+rectangle(
+  coord([0],[0],[0]),
+  coord([1],[1],[1]),
+  paint,
+  [test_leaf,...]
+);
+
+/* 
+ * Draw a 5-pixel-high rectangle between 32357710 and 32357730 bp
+ */
+let test_leaf = leaf("tracks/track/new-track/main/main/content");
+rectangle(
+  coord([32357710],[5],[5]),
+  coord([32357730],[10],[10]),
+  paint,
+  [test_leaf,...]
+);
+
+```
+
+## Optional: Provide metadata about your program
+_NOTE: this step seems to be optional; we have tried skipping it, and nothing bad happened. However, it gives you a chance to describe your program, if for nothing else then at least for documentation purposes._
+
+Look around the `backend-server/egs-data/begs/specs16` directory. Notice that there are a lot of toml files there, each named as corresponding top-level program. If you inspect any of these toml files, you will find that they describe the settings of the corresponding program, with explicit default values. You can do the same for your new program by creating and filling in a `new-track.toml` file in that directory. When you are done, include reference to this file in `programs.toml` in the same directory.
+
+## Include new track drawing program in the compilation script
+The source code of track drawing programs needs to be compiled, which is currently done by the `backend-server/build-begs.sh` script. Inspect it to see how other programs are passed to the eard-compiler, and add yours.
+
+NOTE: The compiler for track drawing programs resides in the `peregrine-eard` repository. You will need to have `peregrine-eard` and `peregrine-eachorevery` repositories available locally (both require Rust, and their source needs to be compiled; see the main `readme.md` file at the top level of this repo for instructions), or use a docker image with `peregrine-eard` already compiled. See how the path to `peregrine-eard` is referenced in the `build-begs.sh` script.
+
+## Use the track
+- Compile track drawing programs by running the `backend-server/build-begs.sh` script.
+- Have the genome browser server running (see the main `readme.md` file at the top level of this repo)
+- Initialise the genome browser on your web page, and pass it a command to show the track. If we take the `peregrine-generic/index.html` as an example, the command will be `genome_browser.switch(["track","new-track"], true)` to show the track; and `genome_browser.switch(["track","new-track", "name"], true)` to toggle the `name` setting of that track to `true`.

--- a/peregrine-generic/regulation.html
+++ b/peregrine-generic/regulation.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css"/>
+  </head>
+  <body>
+  </script>
+    <div class="grid" id="grid">
+      <div class="header" id="header">
+      </div>
+      <div class="viewport" id="browser">
+      </div>
+      <div class="sidebar" id="sidebar">
+        <div class="payload">current: <span id="current"></span></div>
+        <div class="payload">target: <span id="target"></span></div>
+        <table>
+          <thead>
+            <tr>
+              <th>track id</th>
+              <th>offset</th>
+              <th>size</th>
+              <th colspan="4">on/off</th>
+            </tr>
+          </thead>
+          <tbody id="track-metadata">
+          </tbody>
+        </table>
+        <table>
+          <thead>
+            <tr>
+              <th>id</th>
+              <th>state</th>
+              <th>actions</th>
+            </tr>
+          </thead>
+          <tbody id="focus-transcripts">            
+          </tbody>
+        </table>
+        <div id="zmenu-click" class="payload" style="font-size: 10px"></div>
+      </div>
+      <div class="footer" id="footer">
+      </div>
+    </div>
+    <script type="module">
+      import { GenomeBrowser, default as init } from './pkg/peregrine_generic.js';
+      init().then(function() {
+        let genome_browser = new GenomeBrowser();
+        genome_browser.go({
+          backend_url: "http://127.0.0.1:3333/api/data http://127.0.0.1:3334/api/data",
+          target_element_id: 'browser',
+          'keys.debug-action': "Require(drag)-Click[2] Hold[3] HoldDrag[4] DoubleClick[7] 1[1] 2[2] 3[3] 4[4] 5[5] 6[6] 7[7] 8[8] 9[9] 0[0]",
+          'keys.pixels-left': 'Shift-A[100] Alt-a[1000]',
+          'keys.pixels-right': "MirrorRunningDrag Shift-D[100] Alt-d[1000]",
+          'keys.pixels-in': "Shift-W[100]",
+          'keys.pixels-out': "Shift-S[100] Wheel",
+          "keys.pull-left": "a ArrowLeft",
+          "keys.pull-right": "d ArrowRight",
+          "keys.pull-in": "w ArrowUp",
+          "keys.pull-out": "s ArrowDown",
+          "zoom.goto.rho": "1.41",
+          "zoom.goto.v": "0.003",
+        });
+        var seen_transcripts = {};
+        var shown_transcripts = {};
+        var labels = {};
+        var tr_labels = {};
+        var sv_labels = {};
+        var nm_labels = {};
+        var tracks_on = {};
+
+        function tr_all(yn) {
+          for(const tr in seen_transcripts) {
+            if(yn) {
+              shown_transcripts[tr] = 1;
+            } else {
+              delete shown_transcripts[tr];
+            }
+          }
+          genome_browser.switch(["track","focus","enabled-transcripts"],Object.keys(shown_transcripts));
+        }
+
+        function toggle_track(track_name) {
+          let cur = tracks_on[track_name];
+          if(cur!==true && cur!==false) { cur = true; }
+          let value = !cur;
+          tracks_on[track_name] = value;
+          if(value) {
+            genome_browser.switch(["track",track_name],true);
+          } else {
+            genome_browser.switch(["track",track_name],false);
+          }
+        }
+        function toggle_label(track_name) {
+          let cur = labels[track_name];
+          if(cur!==true && cur!==false) { cur = true; }
+          let value = !cur;
+          labels[track_name] = value;
+          if(value) {
+            genome_browser.switch(["track",track_name,"label"],true);
+          } else {
+            genome_browser.switch(["track",track_name,"label"],false);
+          }
+        }
+        function toggle_tr_label(track_name) {
+          let cur = tr_labels[track_name];
+          if(cur!==true && cur!==false) { cur = false; }
+          let value = !cur;
+          tr_labels[track_name] = value;
+          if(value) {
+            genome_browser.switch(["track",track_name,"transcript-label"],true);
+          } else {
+            genome_browser.switch(["track",track_name,"transcript-label"],false);
+          }
+        }
+        function toggle_name(track_name) {
+          let cur = nm_labels[track_name];
+          if(cur!==true && cur!==false) { cur = true; }
+          let value = !cur;
+          nm_labels[track_name] = value;
+          if(value) {
+            genome_browser.switch(["track",track_name,"name"],true);
+          } else {
+            genome_browser.switch(["track",track_name,"name"],false);
+          }
+        }
+        let all_tracks = {};
+        let current_span = document.getElementById("current");
+        let target_span = document.getElementById("target");
+        genome_browser.set_message_reporter(function(kind,...more) {
+          if(kind=="error") {
+              console.error(more[0]);
+          } else if(kind=="current_position") {
+            let currentPosition = more[0];
+              current_span.innerText = `${currentPosition.stick}:${currentPosition.start}-${currentPosition.end}`;
+          } else if(kind=="target_position") {
+              let targetPosition = more[0];
+              target_span.innerText = `${targetPosition.stick}:${targetPosition.start}-${targetPosition.end}`;
+          } else if(kind=="endstops") {
+              console.log("endstops: " + more[0])
+          } else if(kind=="track_summary") {
+            let tbody = document.getElementById("track-metadata");
+            for(const track of more[0].summary) {
+                if(track.type != "track") { continue; } /* don't care */
+                all_tracks[track["switch-id"]] = track;
+            }
+            tbody.innerHTML = "";
+            for(const track_name in all_tracks) {
+                let track = all_tracks[track_name];
+                if(track.type != "track") { continue; } /* don't care */
+                if('all-transcripts' in track) {
+                  let all = track['all-transcripts'];
+                  let new_seen_transcripts = {};
+                  for(let i=0;i<all.length;i++) {
+                    new_seen_transcripts[all[i]] = 1;
+                  }
+                  let pruned = false;
+                  for(const old_seen in seen_transcripts) {
+                    if(!new_seen_transcripts[old_seen]) { pruned = true; }
+                  }
+                  if(pruned) {
+                    genome_browser.switch(["track","focus","enabled-transcripts"],null);
+                  }
+                  seen_transcripts = new_seen_transcripts;
+                  if('transcripts-shown' in track) {
+                    let shown = track['transcripts-shown'];
+                    shown_transcripts = {};
+                    for(const trid of shown) {
+                      if(seen_transcripts[trid]) {
+                        shown_transcripts[trid] = 1;
+                      }
+                    }
+                  }
+                  let trbody = document.getElementById("focus-transcripts");
+                  trbody.innerHTML = "";
+                  for(var trid of Object.keys(seen_transcripts)) {
+                    let trtr = document.createElement("tr");
+                    let trtd1 = document.createElement("td");
+                    trtd1.innerHTML = trid;
+                    let trtd2 = document.createElement("td");
+                    let text = "off";
+                    let action_text = "turn on";
+                    if(shown_transcripts[trid]) { text = "on"; action_text = "turn off"; }
+                    trtd2.innerHTML = text;
+                    let trtd3 = document.createElement("td");
+                    trtd3.innerHTML = "<a href=\"#\">"+action_text+"</a>";
+                    let click_trid = trid;
+                    trtd3.onclick = function() {
+                      if(shown_transcripts[click_trid]) {
+                        delete shown_transcripts[click_trid];
+                      } else {
+                        shown_transcripts[click_trid] = 1;
+                      }
+                      genome_browser.switch(["track","focus","enabled-transcripts"],Object.keys(shown_transcripts));
+                      console.log("sending "+Object.keys(shown_transcripts));
+                    };
+                    trtr.append(trtd1);
+                    trtr.append(trtd2);
+                    trtr.append(trtd3);
+                    trbody.append(trtr);
+                  }
+                }
+                let tr = document.createElement("tr");
+                let data = [track["switch-id"],track.offset,track.height];
+                for(const text of data) {
+                  let td = document.createElement("td");
+                  td.innerText = text;
+                  tr.appendChild(td);
+                }
+                let td1 = document.createElement("td");
+                td1.innerHTML = "<a title='Toggle track'>👁️</a>";
+                td1.onclick = function() { toggle_track(track['switch-id']) };
+                let td2 = document.createElement("td");
+                let td2b = document.createElement("td");
+                let td4 = document.createElement("td");
+                if(track["has-labels"]) {
+                  td2.innerHTML = "<a title='Toggle gene label' class='lbl'>🏷️g</a>";
+                  td2.onclick = function() { toggle_label(track['switch-id']) };
+                  td2b.innerHTML = "<a title='Toggle transcript label' class='lbl'>🏷️t</a>";
+                  td2b.onclick = function() { toggle_tr_label(track['switch-id']) };
+                  td4.innerHTML = "<a title='Toggle multiple transcripts'>≣</a>";
+                  td4.onclick = function() { toggle_several(track['switch-id']) };
+                }
+                let td3 = document.createElement("td");
+                td3.innerHTML = "<a title='Toggle track name' class='lbl'>🏷️n</a>";
+                td3.onclick = function() { toggle_name(track['switch-id']) };
+                tr.appendChild(td1);
+                tr.appendChild(td2);
+                tr.appendChild(td2b);
+                tr.appendChild(td3);
+                tr.appendChild(td4);
+                tbody.appendChild(tr);
+              }
+          } else if(kind=="hotspot") {
+            let zmenu_data_el = document.getElementById("zmenu-click");
+            if(more[0].variety[0].type == "lozenge") {
+              let obj = more[0].content[0];
+              if(obj.focus) {
+                tr_all(!obj.currently_all);
+              }
+            }
+            let zmenu_data = more[0];
+            zmenu_data_el.innerText = JSON.stringify(zmenu_data);
+          }
+        });
+        function delay(t, v) {
+          return new Promise(resolve => setTimeout(resolve, t, v));
+        }
+        /* Set startup view/location */
+        genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
+        genome_browser.switch(["track","gene-pc-fwd"],true);
+        genome_browser.switch(["track","gene-pc-fwd","label"],true);
+        genome_browser.switch(["track","gene-pc-fwd","name"],true);
+        genome_browser.switch(["track","gc"],true);
+        genome_browser.switch(["track","gc","name"],true);
+        genome_browser.switch(["track","contig"],true);
+        genome_browser.switch(["track","contig","name"],true);
+        genome_browser.switch(["track","expand"],true);
+        genome_browser.switch(["ruler"],true);
+        genome_browser.switch(["ruler","one_based"],true);
+
+        genome_browser.switch(["track","regulation"], true);
+        genome_browser.switch(["track","regulation", "name"], true);
+
+        genome_browser.goto(32357706,32357736);
+
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
_**Note:** this branch has been cut from `feature/variation-tracks` branch; so I am creating a PR against that branch to see a clean diff. I'll change the base to master when `feature/variation-tracks` is merged_.

This PR adds a new track for future regulation development. The track doesn't do much; just displays a couple of shapes and the name of the track. Included also is documentation with my best understanding for how to add a track.


The example code in this PR produces the bottom track, called "REGULATION", with a couple of lines, a rectangle, and a text:

<img width="1125" alt="image" src="https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/86b98a89-f08f-412e-a98a-0fa8ceb2c53f">
