### PR TITLE
Fix focus start line label

### DIFF
--- a/backend-server/egs-data/egs/v16/gene/focus-gene-dots.eard
+++ b/backend-server/egs-data/egs/v16/gene/focus-gene-dots.eard
@@ -28,7 +28,7 @@ let **focus_gene = index(**gene,focus_gene_index);
 let leaf_dots = if(on_this_stick,leaf("dots/content"),leaf(""));
 let leaf_text = if(on_this_stick,leaf("tracks/flagtop/main"),leaf(""));
 
-let text_start = comma_format(focus_gene.start);
+let text_start = comma_format(focus_gene.start+1);
 let text_end = comma_format(focus_gene.end);
 
 red_dotted(focus_gene.start,focus_gene.end,text_start,text_end,leaf_dots,leaf_text);

--- a/backend-server/egs-data/egs/v16/other/focus-region.eard
+++ b/backend-server/egs-data/egs/v16/other/focus-region.eard
@@ -17,7 +17,7 @@ let correct_chr = focus_stick == stick();
 let leaf_dots = if(correct_chr,leaf("dots/content"),leaf(""));
 let leaf_text =  if(correct_chr,leaf("tracks/flagtop/main"),leaf(""));
 
-let text_start = comma_format(focus_start);
+let text_start = comma_format(focus_start+1);
 let text_end = comma_format(focus_end);
 
 red_dotted(focus_start,focus_end,text_start,text_end,leaf_dots,leaf_text);


### PR DESCRIPTION
This PR will fix the position shift in the label marking the start line of a focus region or gene (the start line marks the position coming after, not before the line).
Example: [BRCA2 gene on the beta site](https://beta.ensembl.org/genome-browser/grch38?focus=gene:ENSG00000139618&location=13:32272495-32442859) starts at position `...086` while the start line label shows `...085`
JIRA: https://www.ebi.ac.uk/panda/jira/browse/EWB-468
Tested on local sandbox.