### PR TITLE
Increase clickable hotspot height for regulatory features

### DIFF
--- a/backend-server/egs-data/egs/v16/regulation/regulation.eard
+++ b/backend-server/egs-data/egs/v16/regulation/regulation.eard
@@ -30,8 +30,8 @@ let zmenu_leaf = reg_feature.leaf;
 let zmenu_leaf = set(zmenu_leaf, !is_bounds_same_as_core, [leaf(""), ...]);
 
 rectangle(
-    coord(reg_feature.start, [bounds_top_offset,...], [0,...]),
-    coord(reg_feature.end, [bounds_top_offset + bounds_height,...], [0,...]),
+    coord(reg_feature.start, [0,...], [0,...]),
+    coord(reg_feature.end, [core_height,...], [0,...]),
     zmenu_paint,
     zmenu_leaf
 );
@@ -42,8 +42,8 @@ let zmenu_leaf = reg_feature.leaf;
 let zmenu_leaf = set(zmenu_leaf, is_bounds_same_as_core, [leaf(""), ...]);
 
 rectangle(
-    coord(reg_feature.start, [bounds_top_offset,...], [0,...]),
-    coord(reg_feature.end, [bounds_top_offset + bounds_height,...], [0,...]),
+    coord(reg_feature.start, [0,...], [0,...]),
+    coord(reg_feature.end, [core_height,...], [0,...]),
     zmenu_paint,
     zmenu_leaf
 );


### PR DESCRIPTION
**Before** (showing clickable area as black-filled rectangles; you can see that the clickable area has a smaller height than a regulatory feature):

https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/1be1e342-c02f-43f2-99af-35ef016a3d60

**After:**

https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/534bc82f-a05a-4fb5-ab94-43315badbf46
