### PR TITLE
Do not add 1 to end coordinate of regulatory features in zmenu payload

### DIFF
--- a/backend-server/egs-data/egs/v16/regulation/regulation-common.eard
+++ b/backend-server/egs-data/egs/v16/regulation/regulation-common.eard
@@ -102,7 +102,7 @@ export procedure draw_regulatory_features(*reg_feature) {
   /* Draw thinner rectangles for feature boundaries */
   rectangle(
       coord(reg_feature.start, [bounds_top_offset,...], [0,...]),
-      coord(reg_feature.end + 1, [bounds_top_offset + bounds_height,...], [0,...]),
+      coord(reg_feature.end, [bounds_top_offset + bounds_height,...], [0,...]),
       paint,
       reg_feature.leaf
   );
@@ -110,7 +110,7 @@ export procedure draw_regulatory_features(*reg_feature) {
   /* Draw thicker rectangles for feature cores */
   rectangle(
       coord(reg_feature.thick_start, [0,...], [0,...]),
-      coord(reg_feature.thick_end + 1, [core_height,...], [0,...]),
+      coord(reg_feature.thick_end, [core_height,...], [0,...]),
       paint,
       reg_feature.leaf
   );

--- a/backend-server/egs-data/egs/v16/regulation/regulation-zmenu.eard
+++ b/backend-server/egs-data/egs/v16/regulation/regulation-zmenu.eard
@@ -13,9 +13,9 @@ procedure with_ensembl_coordinates(*reg_feature) {
     // Coordinates in bed files (and used in genome browser in general) are zero-based;
     // but the world outside of the genome browser is 1-based
     let reg_feature.ens_start = reg_feature.start + 1;
-    let reg_feature.ens_end = reg_feature.end + 1;
+    let reg_feature.ens_end = reg_feature.end;
     let reg_feature.ens_core_start = reg_feature.thick_start + 1;
-    let reg_feature.ens_core_end = reg_feature.thick_end + 1;
+    let reg_feature.ens_core_end = reg_feature.thick_end;
 
     *reg_feature
 }


### PR DESCRIPTION
## Description

### Background
We were seeing single-nucleotide gaps between adjacent regulation features, and were told that there must be a mistake, because there shouldn't be such a gap:

![image](https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/3fb492b8-b1bd-4f9b-9a66-4412bdcbcc0e)

### Investigation
Here is a read from the regulation bigbed file containing two such adjacent regulatory features:

```
(40182601, 40189201, 'ENSR00000479521\t0\t.\t40188199\t40188400\t255,0,0\t1\t6600\t0\tPromoter')
(40189202, 40195198, 'ENSR00000479520\t0\t.\t40189999\t40190600\t255,0,0\t1\t5996\t0\tPromoter')
```

notice that the end coordinate of the first feature is `40189201`, whereas the start coordinate of the second feature is `40189202`

That means there was a mistake in the data due to conversion from the Ensembl coordinate system to bed coordinate system. In a bed file, the count starts at 0, and the painted feature should not include the end coordinate. In the Ensembl coordinate system, the count starts at 1, and the painted feature should include the end coordinate.

This can be illustrated by the diagram below. Notice that both in the bed format and in the Ensembl counting system, the end coordinate of a feature (coloured in red here) are the same, although the start coordinate differs by 1:

![image](https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/2079591d-8b9c-4e64-a812-506e61ca7848)

What this means is that, in bed format, for one feature to start where the other feature ends, the end coordinate of the first feature should be the same as the start coordinate of the second. But as shown in the two lines from the bed file above, the start of the second feature was right after the end of the first feature. Thus, the gap in the visualisation was caused by a data bug.

### Lessons learnt
The genome browser behaves according to the bed conventions. That is, when we tell the genome browser to draw a rectangle, it starts drawing at the start coordinate, and stops drawing right before the end coordinate.

### So what's in the PR?
I am removing the "+1" from the end coordinate of regulatory features in the zmenu payload. I had it previously, because I did not realise that there was a bug in the data, and was trying to make zmenu message match feature coordinates on the current site.

## Jira ticket
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-1967

## Deployment url
http://regulation.review.ensembl.org/

Compare the same location on staging: https://staging-2020.ensembl.org/genome-browser/grch38?focus=gene:ENSG00000139618&location=13:31945320-31945651 and on the review deployment: http://regulation.review.ensembl.org/genome-browser/grch38?focus=gene:ENSG00000139618&location=13:31945320-31945651