### PR TITLE
Changes needed to use production generated data

### DIFF
--- a/backend-server/app/model/datalocator.py
+++ b/backend-server/app/model/datalocator.py
@@ -31,8 +31,8 @@ class AccessItem(object):
         # "seqs": "seqs/{genome}/{chromosome}",
         "chrom-hashes": "{genome}/chrom.hashes.ncd",
         "chrom-sizes": "{genome}/chrom.sizes.ncd",
-        "species-list": "species.txt",
-        "regulation": "regulation/{genome}/regulatory-features.bb"
+        # "species-list": "species.txt",
+        "regulation": "{genome}/regulatory-features.bb"
     }
 
     def __init__(self, variety: str, genome: str = None, chromosome: str = None):

--- a/backend-server/app/model/datalocator.py
+++ b/backend-server/app/model/datalocator.py
@@ -24,13 +24,13 @@ class AccessItem(object):
     """
 
     variety_map = {
-        "contigs": "contigs/{genome}/contigs.bb",
-        "transcripts": "genes_and_transcripts/{genome}/transcripts.bb",
-        "gc": "gc/{genome}/gc.bw",
-        "jump": "jump/{genome}/jump.ncd",
+        "contigs": "{genome}/contigs.bb",
+        "transcripts": "{genome}/transcripts.bb",
+        "gc": "{genome}/gc.bw",
+        "jump": "{genome}/jump.ncd",
         # "seqs": "seqs/{genome}/{chromosome}",
-        "chrom-hashes": "common_files/{genome}/chrom.hashes.ncd",
-        "chrom-sizes": "common_files/{genome}/chrom.sizes.ncd",
+        "chrom-hashes": "{genome}/chrom.hashes.ncd",
+        "chrom-sizes": "{genome}/chrom.sizes.ncd",
         "species-list": "species.txt",
         "regulation": "regulation/{genome}/regulatory-features.bb"
     }

--- a/backend-server/app/model/species.py
+++ b/backend-server/app/model/species.py
@@ -15,7 +15,7 @@ class Species(object):
     def __init__(self, genome_id, best_name, names, tags):
         self.genome_id = genome_id
         self.genome_path = self.genome_id
-        self.wire_id = re.sub(r'\W', '_', self.genome_id)
+        self.wire_id = self.genome_id
         self.chromosomes = {}
         self.best_name = best_name
         self._names = names

--- a/backend-server/config/sources-ebi-dev.toml
+++ b/backend-server/config/sources-ebi-dev.toml
@@ -1,6 +1,6 @@
 [source.apple]
 driver = "file"
-root = "/usr/data/newsite/dev/genome_browser/7"
+root = "/usr/data/newsite/dev/genome_browser/8"
 refget_url = "http://ensembl-refget-proxy-svc:8083/api/sequence/"
 min_version = 16
 

--- a/backend-server/config/sources-s3.toml
+++ b/backend-server/config/sources-s3.toml
@@ -1,6 +1,6 @@
 [source.apple]
 driver = "s3"
-url = "http://ensembl-2020-gb-flatfiles.s3.eu-west-2.amazonaws.com/upload-20220829/"
+url = "http://ensembl-2020-gb-flatfiles.s3.eu-west-2.amazonaws.com/upload-2023-10-19/"
 refget_url = "https://staging-2020.ensembl.org/api/refget/sequence/"
 min_version = 16
 

--- a/backend-server/config/species-list.toml
+++ b/backend-server/config/species-list.toml
@@ -1,5 +1,5 @@
 [species.grch38]
-path = "homo_sapiens_GCA_000001405.28"
+path = "a7335667-93e7-11ec-a39d-005056b38ce3"
 best_name = "a7335667-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "homo_sapiens_GCA_000001405.28",

--- a/backend-server/config/species-list.toml
+++ b/backend-server/config/species-list.toml
@@ -57,7 +57,7 @@ other_names = [
 ]
 
 [species.ecoli]
-path = "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2"
+path = "a73351f7-93e7-11ec-a39d-005056b38ce3"
 best_name = "a73351f7-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "escherichia_coli_str_k_12_substr_mg1655_gca_000005845_GCA_000005845_2",

--- a/backend-server/config/species-list.toml
+++ b/backend-server/config/species-list.toml
@@ -9,7 +9,7 @@ other_names = [
 tags = ["has-variants"]
 
 [species.grch37]
-path = "homo_sapiens_GCA_000001405.14"
+path = "3704ceb1-948d-11ec-a39d-005056b38ce3"
 best_name = "3704ceb1-948d-11ec-a39d-005056b38ce3"
 other_names = [
     "homo_sapiens_GCA_000001405.14",
@@ -19,7 +19,7 @@ other_names = [
 tags = ["has-variants"]
 
 [species.wheat]
-path = "triticum_aestivum_GCA_900519105.1"
+path = "a73357ab-93e7-11ec-a39d-005056b38ce3"
 best_name = "a73357ab-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "triticum_aestivum_GCA_900519105.1",
@@ -29,7 +29,7 @@ other_names = [
 tags = ["has-variants"]
 
 [species.yeast]
-path = "saccharomyces_cerevisiae_GCA_000146045.2"
+path = "a733574a-93e7-11ec-a39d-005056b38ce3"
 best_name = "a733574a-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "saccharomyces_cerevisiae_GCA_000146045.2",
@@ -39,7 +39,7 @@ other_names = [
 tags = ["has-variants"]
 
 [species.plasmodium]
-path = "plasmodium_falciparum_GCA_000002765.2"
+path = "a73356e1-93e7-11ec-a39d-005056b38ce3"
 best_name = "a73356e1-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "plasmodium_falciparum_GCA_000002765.2",
@@ -48,7 +48,7 @@ other_names = [
 ]
 
 [species.worm]
-path = "caenorhabditis_elegans_GCA_000002985.3"
+path = "a733550b-93e7-11ec-a39d-005056b38ce3"
 best_name = "a733550b-93e7-11ec-a39d-005056b38ce3"
 other_names = [
     "caenorhabditis_elegans_GCA_000002985.3",


### PR DESCRIPTION
Production generated data uses genome_uuid for accessing files and other assets.

The PR is to use production generated data using genome_uuid. 

Review App : http://241-test-gb-data.review.ensembl.org