### PR TITLE
Fix insertion start coordinate reported in zmenu

### DIFF
--- a/backend-server/egs-data/egs/v16/variant/focus-variant-zmenu.eard
+++ b/backend-server/egs-data/egs/v16/variant/focus-variant-zmenu.eard
@@ -1,9 +1,43 @@
+/*
+A NOTE ON INSERTIONS
+
+You will notice in the function below that insertions are treated differently
+than any other variants. The reason for this is as follows.
+
+According to the conventions of the bed format, the location of a zero-length features
+is represented with a start coordinate being equal to the end coordinate
+(because, length = end - start, or 0). Here is what an FAQ from UCSC says on the subject:
+
+"chromStart and chromEnd can be identical, creating a feature of length 0,
+commonly used for insertions. For example, use chromStart=0, chromEnd=0
+to represent an insertion before the first nucleotide of a chromosome."
+
+Notice in the quote above that an insertion is represented by a nucleotide
+right after it. This is different from how we represent insertions
+at Ensembl, where we mark the position of the anchoring nucleotide
+as the one immediately before the insertion.
+
+Thus, to report the coordinate of an insertion, we follow the following logic:
+- We take the end coordinate of the variant in the bed file.
+- Remembering that the bed format is end-exclusive, we move to the nucleotide
+at location end - 1. This is the anchoring nucleotide according to Ensembl conventions
+(the one immediately the left of the insertion).
+- We translate the start coordinate of that nucleotide from bed to Ensembl
+coordinate system by adding 1, i.e.: variant.end - 1 + 1,
+which results in the same number as simply variant.end.
+- This we send to the client as the start coordinate of the insertion,
+- The end coordinate sent to the client is the same as the start.
+*/
+
+
 export function variant_zmenu(*variant) {
-    let tmpl = template_start("{0}:{1}-{2}");
-    let variant_ensembl_start = variant.start + 1;
+    let tmpl = template_start("{0}:{1}");
+
+    // see the explainer note above
+    let variant_ensembl_start = if(variant.variety == "insertion", variant.start, variant.start + 1);
+
     template_set(tmpl,0,variant.chromosome);
     template_set(tmpl,1,comma_format(variant_ensembl_start));
-    template_set(tmpl,2,comma_format(variant.end));
     let position = template_end(tmpl);
 
     struct!(metadata_zmenu,"""


### PR DESCRIPTION
Here's a diagram to illustrate the situation.

<img src="https://github.com/Ensembl/ensembl-dauphin-style-compiler/assets/6834224/edba0626-c775-419b-8e12-10d3c73415e3" width="500" />

An insertion is recorded in a bed file as a feature with start coordinate equal to end coordinate, which is a bit paradoxical, given that starts are inclusive, but ends are exclusive; but there we have it.

Suppose here we are describing an insertion (shown as red dotted lilne), whose start and end coordinates are recorded in the bed file as equal to 76.

Our anchoring nucleotide, according to Ensembl conventions, is the one immediately to the left of the insertion — i.e., at position 75 in bed coordinates, or 76 in Ensembl coordinates. Which means that, for insertions, Ensembl start coordinate is the same as the bed start (or end) coordinate of the variant.


---
I've checked the eard file locally. It compiles, and produces correct start and end variant coordinates in zmenu.