### PR TITLE
Enable focus variant track

### DIFF
--- a/backend-server/config/boot-tracks/boot-tracks-16.toml
+++ b/backend-server/config/boot-tracks/boot-tracks-16.toml
@@ -168,79 +168,10 @@ name = ["track","gc","name"]
 # Variants
 #
 
-[track.variant-1000genomes.general]
-include = ["general"]
-scales = [1,100,4]
-triggers = [["track","variant-1000genomes"]]
-tags= "#has-variants"
-
-[track.variant-1000genomes.settings]
-name = ["track","variant-1000genomes","name"]
-
-[track.variant-dbsnp.general]
-include = ["general"]
-scales = [6,100,4]
-triggers = [["track","variant-dbsnp"]]
-tags = "#has-variants"
-
-[track.variant-dbsnp.settings]
-name = ["track","variant-dbsnp","name"]
-
-[track.variant-dbsnp-detail.general]
-include = ["general"]
-scales = [1,5,1]
-triggers = [["track","variant-dbsnp"]]
-tags= "#has-variants"
-
-[track.variant-dbsnp-detail.settings]
-name = ["track","variant-dbsnp","name"]
-label-snv-id = ["track","variant-dbsnp","label-snv-id"]
-label-snv-alleles = ["track","variant-dbsnp","label-snv-alleles"]
-label-other-id = ["track","variant-dbsnp","label-other-id"]
-label-other-alleles = ["track","variant-dbsnp","label-other-alleles"]
-show-extents = ["track","variant-dbsnp","show-extents"]
-
-[track.variant-clinvar.general]
-include = ["general"]
-scales = [1,100,4]
-triggers = [["track","variant-clinvar"]]
-tags = "#has-variants"
-
-[track.variant-clinvar.settings]
-name = ["track","variant-clinvar","name"]
-
-[track.variant-gwas.general]
-include = ["general"]
-scales = [1,100,4]
-triggers = [["track","variant-gwas"]]
-tags = "#has-variants"
-
-[track.variant-gwas.settings]
-name = ["track","variant-gwas","name"]
-
-[track.variant-eva.general]
-include = ["general"]
-scales = [1,100,4]
-triggers = [["track","variant-eva"]]
-tags = "#has-variants"
-
-[track.variant-eva.settings]
-name = ["track","variant-eva","name"]
-
-[track.variant-sgrp.general]
-include = ["general"]
-scales = [1,100,4]
-triggers = [["track","variant-sgrp"]]
-tags = "#has-variants"
-
-[track.variant-sgrp.settings]
-name = ["track","variant-sgrp","name"]
-
 [track.focus-variant.general]
 include = ["general"]
 scales = [1,5,1]
 triggers = [["track","focus","item","variant"]]
-tags= "#has-variants"
 
 [track.focus-variant.settings]
 focus-variant = ["track","focus","item","variant"]
@@ -255,7 +186,6 @@ show-extents = ["track","focus","variant","show-extents"]
 include = ["general"]
 scales = [6,100,4]
 triggers = [["track","focus","item","variant"]]
-tags= "#has-variants"
 
 [track.focus-variant-summary.settings]
 focus-variant = ["track","focus","item","variant"]


### PR DESCRIPTION
Enable (the option to use) focus variant track on all species by removing dependency on `has-variants` tag (originally sourced from species list toml file which we don't use anymore).
JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2301
Review app: http://fix-focus-variant.review.ensembl.org/genome-browser/4106e9ef-1bb1-4ca4-974c-8de8875b8456?focus=variant:7:16819049:rs208649716