### PR TITLE
Handle data gaps in GC track

### DIFF
--- a/backend-server/app/data/v16/wiggle/gc.py
+++ b/backend-server/app/data/v16/wiggle/gc.py
@@ -1,5 +1,4 @@
-import os.path
-
+import math
 from command.coremodel import DataHandler, Panel, DataAccessor
 from command.response import Response
 from model.bigbed import get_bigwig_stats, get_bigwig
@@ -29,8 +28,7 @@ def _get_gc(data_accessor: DataAccessor, chrom: Chromosome, panel: Panel) -> Res
         (data, start, end) = get_bigwig(data_accessor, item, panel.start, panel.end)
     else:
         (data, start, end) = get_bigwig_stats(data_accessor, item, panel.start, panel.end)
-
-    data = [1.0 if x is None else x for x in data]
+    data = [1.0 if x is None or math.isnan(x) else x for x in data]
     data = bytearray([round(x / SCALE) for x in data])
     return {
         "values": data_algorithm("NDZRL",data),

--- a/backend-server/app/model/bigbed.py
+++ b/backend-server/app/model/bigbed.py
@@ -38,7 +38,8 @@ def _get_bigbed_data(path, chrom, start, end):
             _bigbeds[path] = pyBigWig.open(path)
         bb = _bigbeds[path]
         out = bb.entries(chrom.name, start, end) or []
-    except (RuntimeError, OverflowError):
+    except (RuntimeError, OverflowError) as e:
+        print(f"Error reading BigBed from {path}: {e}")
         out = []
     return out
 
@@ -80,6 +81,7 @@ def _get_bigwig_stats_data(path, chrom, start, end, consolidation="mean", nBins=
         bw = _bigwigs[path]
         out = bw.stats(chrom.name, start, end, nBins=nBins, type=consolidation) or []
     except (RuntimeError, OverflowError, RequestException) as e:
+        print(f"Error reading BigWig from {path}: {e}")
         out = []
     return out, start, end
 
@@ -113,6 +115,7 @@ def _get_bigwig_data(path, chrom, start, end):
         bw = _bigwigs[path]
         out = bw.values(chrom.name, start, end) or []
     except (RuntimeError, OverflowError, RequestException) as e:
+        print(f"Error reading BigWig from {path}: {e}")
         out = []
     return out, start, end
 

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -325,20 +325,18 @@
         document.getElementById("jump-ins").onclick = jump_variant.bind(this, "rs1639760668", 1, 47376);
 
         document.getElementById("jump-brca2").onclick = function() {
-          genome_browser.jump("focus:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618");
-          genome_browser.wait();
-          genome_browser.switch(["track","focus","item","gene"],{ 
-            "genome_id": "homo_sapiens_GCA_000001405_28", "item_id": "ENSG00000139618" 
-          });
           genome_browser.switch(["track","focus","enabled-transcripts"],null);
+          genome_browser.switch(["track","focus","item","gene"],{ 
+            "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3", "item_id": "ENSG00000139618" 
+          });
+          genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618");
         };
         document.getElementById("jump-fry").onclick = function() {
-          genome_browser.jump("focus:homo_sapiens_GCA_000001405_28:ENSG00000073910");
-          genome_browser.wait();
-          genome_browser.switch(["track","focus","item","gene"],{ 
-            "genome_id": "homo_sapiens_GCA_000001405_28", "item_id": "ENSG00000073910" 
-          });
           genome_browser.switch(["track","focus","enabled-transcripts"],null);
+          genome_browser.switch(["track","focus","item","gene"],{ 
+            "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3", "item_id": "ENSG00000073910" 
+          });
+          genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000073910");
         };
         document.getElementById("jump-wheat").onclick = function() {
           genome_browser.switch(["track","focus","enabled-transcripts"],null);
@@ -394,11 +392,11 @@
 
         genome_browser.switch(["ruler"], true);
         genome_browser.switch(["ruler", "one_based"], true);
-        genome_browser.switch(["track", "focus"], true);
         init_tracks(["gene-pc-forward","contig","gc","regulation","focus"]);
         init_variant_track("0adabdbc-e0a5-487d-a712-98e6127712f2");
         jump_variant("rs1557469781", 1, 1176408);
-        
+        //genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
+        //genome_browser.goto(159980000,160000500);
       });
     </script>
   </body>


### PR DESCRIPTION
This PR allows GC% track to handle  regions with no data in the datafile (shows as `nan` in python).