### PR TITLE
Deploy GB feature branch in new cluster

### DIFF
--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -134,7 +134,7 @@ Review:WP51:HL:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
     # Create review namespace and remove existing review GB ingress
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f - || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -140,6 +140,7 @@ Review:WP51:HL:
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
 
 StopReview:WP51:HL:
+  stage: deploy
   environment:
     name: wp51-hl-development
     action: stop

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -70,7 +70,7 @@ variables:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   script:
     # Download kustomize manifests and update nfs server/path
-    - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
+    - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_PATH>#${NFS_PATH}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/lo/nfs-deployment.patch.yaml
@@ -148,7 +148,7 @@ SetupReview:WP51:HL:
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:
     # Download kustomize manifests and update nfs server/path
-    - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
+    - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     # Prepare/apply secrets, configmap, hi/lo service and ingress manifests
     - cd ensembl-k8s-manifests
     - kubectl apply -f genome-browser/review/sources-toml-configmap.yaml

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -128,10 +128,10 @@ Dev:WP51:HL:
 
 Review:WP51:HL:
   extends: .deploy_backend_review
-  on_stop: StopReview:WP51:HL
   environment:
     name: wp51-hl-development
     url: http://$CI_COMMIT_REF_SLUG.review.ensembl.org
+    on_stop: StopReview:WP51:HL
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
@@ -145,6 +145,8 @@ StopReview:WP51:HL:
     action: stop
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
+  variables:
+    GIT_STRATEGY: none # Don't clone the repository
   when: manual
   allow_failure: true
   script:

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -78,7 +78,6 @@ variables:
     # Update docker image
     - cd ${BASE}/deploy
     - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
-    - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
     # Build hi/lo deployment/configmap manifests and apply
     - kubectl apply -k .
 
@@ -127,6 +126,8 @@ Review:WP51:HL:
   extends: .deploy_backend_review
   environment:
     name: wp51-hl-development
+    kubernetes:
+      namespace: ${CI_COMMIT_REF_SLUG}
 
 SetupReview:WP51:HL:
   stage: setup
@@ -141,8 +142,8 @@ SetupReview:WP51:HL:
       when: on_success
     - when: never
   before_script:
-    # Create review namespace and remove existing review GB ingress
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true
+    # Check for review namespace and remove ingress for default gb backend
+    - kubectl get namespace ${CI_COMMIT_REF_SLUG} # Cancels the job/pipeline if namespace not found
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -154,6 +154,8 @@ SetupReview:WP51:HL:
     - kubectl apply -f genome-browser/memcached/configmap.yaml
     - kubectl apply -f genome-browser/memcached/deployment.yaml
     - kubectl apply -f genome-browser/memcached/service.yaml
+    - kubeclt apply -f genome-browser/review/sources-toml-configmap.yaml
+    - kubeclt apply -f genome-browser/review/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .
     - cp genome-browser/review/lo/svc/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -149,8 +149,11 @@ SetupReview:WP51:HL:
   script:
     # Download kustomize manifests and update nfs server/path
     - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    # Prepare/apply hi/lo review service and ingress manifests
+    # Prepare/apply memcached, gb hi/lo service and ingress manifests
     - cd ensembl-k8s-manifests
+    - kubectl apply -f genome-browser/memcached/configmap.yaml
+    - kubectl apply -f genome-browser/memcached/deployment.yaml
+    - kubectl apply -f genome-browser/memcached/service.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .
     - cp genome-browser/review/lo/svc/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -140,6 +140,8 @@ Review:WP51:HL:
   after_script:
     # Update hi/lo review ingress manifests and apply in review namespace
     - cd ../..
+    - pwd
+    - ls
     - cp review-setup/ingress-host.patch.yaml ./
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
     - cp genome-browser/review/hi/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -69,20 +69,18 @@ variables:
 .deploy_backend_base:
   stage: deploy
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
-  before_script:
+  script:
+    # Download kustomize manifests and update nfs server/path
     - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - git -C ensembl-k8s-manifests/ checkout k8s123-migration
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_PATH>#${NFS_PATH}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/lo/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_PATH>#${NFS_PATH}#g" ${BASE}/lo/nfs-deployment.patch.yaml
-
-  script:
     # Update docker image
     - cd ${BASE}/deploy
     - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
-
-    # Update hi/lo configuration and apply
+    # Build hi/lo deployment/configmap manifests and apply
     - kustomize build . | kubectl apply -f -
 
   needs: ["BE-Docker"]
@@ -107,46 +105,26 @@ Production:WP40:HL:
   extends: .deploy_backend
   environment:
     name: wp40-hl-prod
-  variables:
-    BASE: ensembl-k8s-manifests/genome-browser
-    NFS_SERVER: ${HL_NFS_SERVER_CODON}
-    NFS_PATH: ${HL_NFS_PATH_CODON}
 
 Production:WP41:HX:
   extends: .deploy_backend
   environment:
     name: wp41-hx-prod
-  variables:
-    BASE: ensembl-k8s-manifests/genome-browser
-    NFS_SERVER: ${HL_NFS_SERVER_CODON}
-    NFS_PATH: ${HL_NFS_PATH_CODON}
 
 Staging:WP40:HL:
   extends: .deploy_backend
   environment:
     name: wp40-hl-staging
-  variables:
-    BASE: ensembl-k8s-manifests/genome-browser
-    NFS_SERVER: ${HL_NFS_SERVER_CODON}
-    NFS_PATH: ${HL_NFS_PATH_CODON}
 
 Internal:WP40:HL:
   extends: .deploy_backend
   environment:
     name: wp40-hl-internal
-  variables:
-    BASE: ensembl-k8s-manifests/genome-browser
-    NFS_SERVER: ${HL_NFS_SERVER_CODON}
-    NFS_PATH: ${HL_NFS_PATH_CODON}
 
 Dev:WP51:HL:
   extends: .deploy_backend
   environment:
     name: wp51-hl-development
-  variables:
-    BASE: ensembl-k8s-manifests/genome-browser
-    NFS_SERVER: ${HL_NFS_SERVER_CODON}
-    NFS_PATH: ${HL_NFS_PATH_CODON}
 
 Review:WP51:HL:
   extends: .deploy_backend_review
@@ -158,6 +136,8 @@ Review:WP51:HL:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
     - kubectl create namespace ${CI_COMMIT_REF_SLUG}
+    - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
+    - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
 
 StopReview:WP51:HL:
   environment:

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -6,7 +6,9 @@ stages:
 variables:
   DOCKER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}
   DOCKER_TLS_CERTDIR: ""
-  BASE: backend-server/k8s/base
+  BASE: ensembl-k8s-manifests/genome-browser
+  NFS_SERVER: ${HL_NFS_SERVER_CODON}
+  NFS_PATH: ${HL_NFS_PATH_CODON}
 
 .build-eardo:
   stage: build-eardo
@@ -64,8 +66,7 @@ variables:
 
   needs: ["BE-eardo"]
 
-.deploy_backend:
-  extends: .base-be-deploy-rules
+.deploy_backend_base:
   stage: deploy
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   before_script:
@@ -85,6 +86,16 @@ variables:
     - kustomize build . | kubectl apply -f -
 
   needs: ["BE-Docker"]
+
+.deploy_backend:
+  extends:
+    - .deploy_backend_base
+    - .base-be-deploy-rules
+
+.deploy_backend_review:
+  extends:
+    - .deploy_backend_base
+    - .base-be-deploy-rules-branches
 
 BE-eardo:
   extends: .build-eardo
@@ -136,4 +147,26 @@ Dev:WP51:HL:
     BASE: ensembl-k8s-manifests/genome-browser
     NFS_SERVER: ${HL_NFS_SERVER_CODON}
     NFS_PATH: ${HL_NFS_PATH_CODON}
+
+Review:WP51:HL:
+  extends: .deploy_backend_review
+  on_stop: StopReview:WP51:HL
+  environment:
+    name: wp51-hl-development
+    url: http://$CI_COMMIT_REF_SLUG.review.ensembl.org
+    kubernetes:
+      namespace: ${CI_COMMIT_REF_SLUG}
+  before_script:
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG}
+
+StopReview:WP51:HL:
+  environment:
+    name: wp51-hl-development
+    action: stop
+    kubernetes:
+      namespace: ${CI_COMMIT_REF_SLUG}
+  when: manual
+  allow_failure: true
+  script:
+    - kubectl delete namespace ${CI_COMMIT_REF_SLUG}
 

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -139,7 +139,6 @@ Review:WP51:HL:
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   after_script:
     # Update hi/lo review ingress manifests and apply in review namespace
-    - cd ../..
     - pwd
     - ls
     - cp review-setup/ingress-host.patch.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -70,7 +70,7 @@ variables:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   script:
     # Download kustomize manifests and update nfs server/path
-    - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
+    - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_PATH>#${NFS_PATH}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/lo/nfs-deployment.patch.yaml

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -137,10 +137,10 @@ Review:WP51:HL:
     - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
-  after_script:
+  script:
     # Update hi/lo review ingress manifests and apply in review namespace
-    - pwd
-    - ls
+    - !reference [.deploy_backend_review, script] # Include the script from the parent job
+    - cd ../../
     - cp review-setup/ingress-host.patch.yaml ./
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
     - cp genome-browser/review/hi/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -78,8 +78,9 @@ variables:
     # Update docker image
     - cd ${BASE}/deploy
     - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
+    - kustomize edit set namespace ${CI_COMMIT_REF_SLUG}
     # Build hi/lo deployment/configmap manifests and apply
-    - kustomize build . | kubectl apply -f -
+    - kubectl apply -k .
 
 .deploy_backend:
   extends:
@@ -126,8 +127,6 @@ Review:WP51:HL:
   extends: .deploy_backend_review
   environment:
     name: wp51-hl-development
-    kubernetes:
-      namespace: ${CI_COMMIT_REF_SLUG}
 
 SetupReview:WP51:HL:
   stage: setup

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -154,8 +154,7 @@ SetupReview:WP51:HL:
     - kubectl apply -f genome-browser/memcached/configmap.yaml
     - kubectl apply -f genome-browser/memcached/deployment.yaml
     - kubectl apply -f genome-browser/memcached/service.yaml
-    - ls genome-browser/review
-    - kubeclt apply -f genome-browser/review/sources-toml-configmap.yaml
+    - kubectl apply -f genome-browser/review/sources-toml-configmap.yaml
     - kubeclt apply -f genome-browser/base/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -152,7 +152,7 @@ SetupReview:WP51:HL:
     # Prepare/apply secrets, configmap, hi/lo service and ingress manifests
     - cd ensembl-k8s-manifests
     - kubectl apply -f genome-browser/review/sources-toml-configmap.yaml
-    - sed -i "s#<CM_PREFIX>#${CI_COMMIT_REF_SLUG}#g" genome-browser/review/secrets.yaml
+    - sed -i "s#<MC_PREFIX>#${CI_COMMIT_REF_SLUG}#g" genome-browser/review/secrets.yaml
     - kubectl apply -f genome-browser/review/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -155,7 +155,7 @@ SetupReview:WP51:HL:
     - kubectl apply -f genome-browser/memcached/deployment.yaml
     - kubectl apply -f genome-browser/memcached/service.yaml
     - kubeclt apply -f genome-browser/review/sources-toml-configmap.yaml
-    - kubeclt apply -f genome-browser/review/secrets.yaml
+    - kubeclt apply -f genome-browser/base/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .
     - cp genome-browser/review/lo/svc/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -155,7 +155,7 @@ SetupReview:WP51:HL:
     - kubectl apply -f genome-browser/memcached/deployment.yaml
     - kubectl apply -f genome-browser/memcached/service.yaml
     - kubectl apply -f genome-browser/review/sources-toml-configmap.yaml
-    - kubeclt apply -f genome-browser/base/secrets.yaml
+    - kubectl apply -f genome-browser/base/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .
     - cp genome-browser/review/lo/svc/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -151,8 +151,10 @@ SetupReview:WP51:HL:
     - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     # Prepare/apply hi/lo review service and ingress manifests
     - cd ensembl-k8s-manifests
-    - kubectl apply -k genome-browser/review/hi/svc
-    - kubectl apply -k genome-browser/review/lo/svc
+    - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
+    - kubectl apply -k .
+    - cp genome-browser/review/lo/svc/*.yaml ./
+    - kubectl apply -k .
     - cp review-setup/ingress-host.patch.yaml ./
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
     - cp genome-browser/review/hi/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - build-eardo
   - build
+  - setup
   - deploy
 
 variables:
@@ -131,19 +132,28 @@ Review:WP51:HL:
     name: wp51-hl-development
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
+
+SetupReview:WP51:HL:
+  extends: .base-be-deploy-rules-branches
+  environment:
+    name: wp51-hl-development
+    kubernetes:
+      namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
     # Create review namespace and remove existing review GB ingress
     - kubectl -n ensembl-dev create namespace ${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:
-    # Update hi/lo review ingress manifests and apply in review namespace
-    - !reference [.deploy_backend_review, script] # Include the script from the parent job
-    - cd ../../
+    # Download kustomize manifests and update nfs server/path
+    - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
+    # Prepare/apply hi/lo review service and ingress manifests
+    - cd ensembl-k8s-manifests
+    - kubectl -k genome-browser/review/hi/svc
+    - kubectl -k genome-browser/review/lo/svc
     - cp review-setup/ingress-host.patch.yaml ./
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
     - cp genome-browser/review/hi/*.yaml ./
-    - kustomize build ./ | kubectl apply -f -
+    - kubectl -k .
     - cp genome-browser/review/lo/*.yaml ./
-    - kustomize build ./ | kubectl apply -f -
-
+    - kubectl -k .

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -65,8 +65,6 @@ variables:
     - docker rmi ${DOCKER_IMAGE}
     - docker logout $CI_REGISTRY
 
-  needs: ["BE-eardo"]
-
 .deploy_backend_base:
   stage: deploy
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
@@ -82,8 +80,6 @@ variables:
     - kustomize edit set image DOCKER_IMAGE=${DOCKER_IMAGE}
     # Build hi/lo deployment/configmap manifests and apply
     - kustomize build . | kubectl apply -f -
-
-  needs: ["BE-Docker"]
 
 .deploy_backend:
   extends:
@@ -155,11 +151,11 @@ SetupReview:WP51:HL:
     - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     # Prepare/apply hi/lo review service and ingress manifests
     - cd ensembl-k8s-manifests
-    - kubectl -k genome-browser/review/hi/svc
-    - kubectl -k genome-browser/review/lo/svc
+    - kubectl apply -k genome-browser/review/hi/svc
+    - kubectl apply -k genome-browser/review/lo/svc
     - cp review-setup/ingress-host.patch.yaml ./
     - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
     - cp genome-browser/review/hi/*.yaml ./
-    - kubectl -k .
+    - kubectl apply -k .
     - cp genome-browser/review/lo/*.yaml ./
-    - kubectl -k .
+    - kubectl apply -k .

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -134,11 +134,15 @@ Review:WP51:HL:
       namespace: ${CI_COMMIT_REF_SLUG}
 
 SetupReview:WP51:HL:
-  extends: .base-be-deploy-rules-branches
+  stage: setup
   environment:
     name: wp51-hl-development
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
+  rules: # Run only when a new branch is created
+    - if: $CI_PIPELINE_SOURCE == "push" && 
+          $CI_COMMIT_BEFORE_SHA == "0000000000000000000000000000000000000000"
+      when: always
   before_script:
     # Create review namespace and remove existing review GB ingress
     - kubectl -n ensembl-dev create namespace ${CI_COMMIT_REF_SLUG} || true

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -71,8 +71,7 @@ variables:
   image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   script:
     # Download kustomize manifests and update nfs server/path
-    - git clone https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    - git -C ensembl-k8s-manifests/ checkout k8s123-migration
+    - git clone --depth 1 --branch k8s123-migration https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_PATH>#${NFS_PATH}#g" ${BASE}/hi/nfs-deployment.patch.yaml
     - sed -i "s#<NFS_SERVER>#${NFS_SERVER}#g" ${BASE}/lo/nfs-deployment.patch.yaml
@@ -134,7 +133,7 @@ Review:WP51:HL:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
     # Create review namespace and remove existing review GB ingress
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f - || true
+    - kubectl -n ensembl-dev create namespace ${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -154,6 +154,7 @@ SetupReview:WP51:HL:
     - kubectl apply -f genome-browser/memcached/configmap.yaml
     - kubectl apply -f genome-browser/memcached/deployment.yaml
     - kubectl apply -f genome-browser/memcached/service.yaml
+    - ls genome-browser/review
     - kubeclt apply -f genome-browser/review/sources-toml-configmap.yaml
     - kubeclt apply -f genome-browser/base/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -1,7 +1,7 @@
 stages:
+  - setup
   - build-eardo
   - build
-  - setup
   - deploy
 
 variables:
@@ -143,19 +143,17 @@ SetupReview:WP51:HL:
     - when: never
   before_script:
     # Create review namespace and remove existing review GB ingress
-    - kubectl -n ensembl-dev create namespace ${CI_COMMIT_REF_SLUG} || true
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
   script:
     # Download kustomize manifests and update nfs server/path
     - git clone --depth 1 --branch k8s123-migration-gb https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests.git
-    # Prepare/apply memcached, gb hi/lo service and ingress manifests
+    # Prepare/apply secrets, configmap, hi/lo service and ingress manifests
     - cd ensembl-k8s-manifests
-    - kubectl apply -f genome-browser/memcached/configmap.yaml
-    - kubectl apply -f genome-browser/memcached/deployment.yaml
-    - kubectl apply -f genome-browser/memcached/service.yaml
     - kubectl apply -f genome-browser/review/sources-toml-configmap.yaml
-    - kubectl apply -f genome-browser/base/secrets.yaml
+    - sed -i "s#<CM_PREFIX>#${CI_COMMIT_REF_SLUG}#g" genome-browser/review/secrets.yaml
+    - kubectl apply -f genome-browser/review/secrets.yaml
     - cp genome-browser/review/hi/svc/*.yaml ./ # kustomize restrictions workaround
     - kubectl apply -k .
     - cp genome-browser/review/lo/svc/*.yaml ./

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -130,8 +130,6 @@ Review:WP51:HL:
   extends: .deploy_backend_review
   environment:
     name: wp51-hl-development
-    url: http://$CI_COMMIT_REF_SLUG.review.ensembl.org
-    on_stop: StopReview:WP51:HL
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
@@ -148,18 +146,4 @@ Review:WP51:HL:
     - kustomize build ./ | kubectl apply -f -
     - cp genome-browser/review/lo/*.yaml ./
     - kustomize build ./ | kubectl apply -f -
-
-StopReview:WP51:HL:
-  stage: deploy
-  environment:
-    name: wp51-hl-development
-    action: stop
-    kubernetes:
-      namespace: ensembl-dev
-  variables:
-    GIT_STRATEGY: none # Don't clone the repository
-  when: manual
-  allow_failure: true
-  script:
-    - kubectl delete namespace ${CI_COMMIT_REF_SLUG}
 

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -135,6 +135,7 @@ Review:WP51:HL:
 
 SetupReview:WP51:HL:
   stage: setup
+  image: dockerhub.ebi.ac.uk/ensembl-web/deploy-tools:latest
   environment:
     name: wp51-hl-development
     kubernetes:
@@ -142,7 +143,8 @@ SetupReview:WP51:HL:
   rules: # Run only when a new branch is created
     - if: $CI_PIPELINE_SOURCE == "push" && 
           $CI_COMMIT_BEFORE_SHA == "0000000000000000000000000000000000000000"
-      when: always
+      when: on_success
+    - when: never
   before_script:
     # Create review namespace and remove existing review GB ingress
     - kubectl -n ensembl-dev create namespace ${CI_COMMIT_REF_SLUG} || true

--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -135,9 +135,19 @@ Review:WP51:HL:
     kubernetes:
       namespace: ${CI_COMMIT_REF_SLUG}
   before_script:
-    - kubectl create namespace ${CI_COMMIT_REF_SLUG}
+    # Create review namespace and remove existing review GB ingress
+    - kubectl create namespace ${CI_COMMIT_REF_SLUG} --dry-run=client -o yaml | kubectl apply -f -
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-hi-${CI_COMMIT_REF_SLUG} || true
     - kubectl -n ensembl-dev delete ingress genome-browser-server-ingress-lo-${CI_COMMIT_REF_SLUG} || true
+  after_script:
+    # Update hi/lo review ingress manifests and apply in review namespace
+    - cd ../..
+    - cp review-setup/ingress-host.patch.yaml ./
+    - sed -i "s#<HOST>#${CI_COMMIT_REF_SLUG}.review.ensembl.org#g" ingress-host.patch.yaml
+    - cp genome-browser/review/hi/*.yaml ./
+    - kustomize build ./ | kubectl apply -f -
+    - cp genome-browser/review/lo/*.yaml ./
+    - kustomize build ./ | kubectl apply -f -
 
 StopReview:WP51:HL:
   stage: deploy
@@ -145,7 +155,7 @@ StopReview:WP51:HL:
     name: wp51-hl-development
     action: stop
     kubernetes:
-      namespace: ${CI_COMMIT_REF_SLUG}
+      namespace: ensembl-dev
   variables:
     GIT_STRATEGY: none # Don't clone the repository
   when: manual


### PR DESCRIPTION
### Description
Adds review job in GitLab CI/CD pipeline in order to deploy Genome Browser non-default backend (feature branch) to review app namespace in the new dev cluster.

### Related JIRA Issue(s)
[ENSWBSITES-2460](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2460)

### Review App URL(s)
http://deploy-review-nkhdev.review.ensembl.org
http://another-branch.review.ensembl.org

### Example(s)
Example tests:
- Check CI/CD pipeline logs in [GitLab](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-dauphin-style-compiler/-/pipelines)
- Check the resources deployed in review namespace:
`[ens_adm02@wp-np3-32 ~]$ nkhdev -n deploy-review-nkhdev get deploy,svc,ing,cm,secret`
- Check genome browser in the [review app](http://deploy-review-nkhdev.review.ensembl.org)

You can test deploying your own GB review deployments by creating a new branch from `deploy-review-nkhdev`. Before branching GB, do the same for ensembl-client (create a branch from `deploy-review-nkhdev`) - ensembl-client will setup the review namespace and image pull secrets.

### Dependencies
Two other repos have updates that this PR depends on:
- The review setup job uses `k8s123-migration-gb` branch from [ensembl-k8s-manifests repo](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests). [See the MR](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests/-/merge_requests/34) for the changes.
- The k8s review namespace is created by ci/cd pipeline triggered by corresponding feature branch in [ensembl-client](https://github.com/Ensembl/ensembl-client). [See the PR](https://github.com/Ensembl/ensembl-client/pull/1101) for details.

Actions: 
1. Approve & merge the MR/PR above. 
2. Revert the branchname in GB review job to `k8s123-migration`