### PR TITLE
PR Template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,36 @@
+### Description
+<!--
+_Using one or more sentences, describe the proposed changes and the reason for making them._
+-->
+
+### Related JIRA Issue(s)
+<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->
+
+### Review App URL(s) 
+http://__BRANCH_NAME_HERE__.review.ensembl.org
+
+### Knowledge Base
+<!--
+_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
+-->
+
+### Example(s)
+<!--
+_Any details that will help reviewers to review the PR, such as  (but not limited to ) expected request/response, instruction for viewing the changes via the web client, or any other relevant information._
+-->
+
+### Data Availability
+
+<!--
+_Is the data required for changes copied to appropriate locaion?_
+-->
+
+### Checklist
+
+- [ ] Black formatting
+- [ ] Tests
+
+### Dependencies 
+<!--
+_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
+-->


### PR DESCRIPTION
### Description
There is no PR template which can be used for Backend APIs. The PR template is derived from the base template.

### Related JIRA Issue(s)


### Review App URL(s) 
None

### Knowledge Base
https://medium.com/@swapnesh/why-you-should-add-a-pull-request-template-in-your-github-project-1556170e55c9

### Test(s)/Example(s)
See example section in this PR https://github.com/Ensembl/ensembl-web-metadata-api/pull/48

### Data Availability
Data updates not required

### Dependencies 
None