### PR TITLE
Removed score from z-menu for simple feature tracks

### DIFF
--- a/backend-server/egs-data/egs/v16/simple-features/simple-features.eard
+++ b/backend-server/egs-data/egs/v16/simple-features/simple-features.eard
@@ -41,29 +41,18 @@ function feature_zmenu(*element) {
           {"markup": ["light"], "text": ")"}
         ],
         "type": "block"
-      }],
-      /* Third row */
-      [{
-        "items": [
-          {"markup": ["light"], "text": "Score"},
-          {"markup": [], "text": " "},
-          {"markup": ["strong"], "text": <3n>}
-        ],
-        "type": "block"
       }]
     ],
     "metadata": {
       "type": <0s>,
       "location": <1s>,
-      "strand": <2s>,
-      "score": <3n>
+      "strand": <2s>
     }
   })
   """,
   element.analysis,
   location,
-  element.strand,
-  element.score
+  element.strand
   );
 
   paint_click(zmenu_metadata, zmenu_content, false) //returns this


### PR DESCRIPTION
### Description
Small change to simple feature tracks to remove the score from the z-menu

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2501

### Review App URL(s) 
http://jk-simple-features-hide-score.review.ensembl.org


### Example(s)
Pig is the only species with simple feature tracks 
http://jk-simple-features-hide-score.review.ensembl.org/genome-browser/da38d82b-df50-419b-af74-886463b7bfa3?focus=gene:ENSSSCG00000009657&location=14:10294456-10477176

