### PR TITLE
Conservation score track improvements

### DIFF
--- a/backend-server/app/command/datacmd.py
+++ b/backend-server/app/command/datacmd.py
@@ -11,7 +11,8 @@ from data.v16.variant import VariantLabelsDataHandler, VariantSummaryDataHandler
 from data.v16.regulation import RegulationDataHandler
 from data.v16.contig import ShimmerContigDataHandler16
 from data.v16.contig import ContigDataHandler16
-from data.v16.wiggle import GCWiggleDataHandler, ComparaWiggleDataHandler
+from data.v16.gc import GCWiggleDataHandler
+from data.v16.conservation_scores import ConservationScoresWiggleDataHandler
 from data.v16.sequence import ZoomedSeqDataHandler16
 from data.v16.gene.genedata import TranscriptDataHandler16
 from data.v16.gene.genedata import GeneDataHandler16
@@ -32,7 +33,7 @@ handlers = [
     ("variant-summary", VariantSummaryDataHandler(), 16),
     ("variant-details", VariantLabelsDataHandler(), 16),
     ("regulation", RegulationDataHandler(), 16),
-    ("compara-scores", ComparaWiggleDataHandler(), 16),
+    ("compara-scores", ConservationScoresWiggleDataHandler(), 16),
     ("compara-elements", ComparaDataHandler(), 16),
     ("repeats", RepeatsDataHandler(), 16),
     ("simple-features", SimpleFeaturesDataHandler(), 16),

--- a/backend-server/app/data/v16/conservation_scores.py
+++ b/backend-server/app/data/v16/conservation_scores.py
@@ -44,7 +44,7 @@ def get_wiggle_data_for_conservation_scores( data_accessor: DataAccessor, panel:
         "normalized_values": data_algorithm("NDZRL", bytearray(normalized_data)),
         "conservation_scores": data_algorithm("SZ", scores),
         "overflow_flags": data_algorithm("NDZRL", overflow_flags),
-        "range": data_algorithm("NRL", [start+1, end+1])
+        "range": data_algorithm("NRL", [start, end])
     }
 
 class ConservationScoresWiggleDataHandler(DataHandler):

--- a/backend-server/app/data/v16/conservation_scores.py
+++ b/backend-server/app/data/v16/conservation_scores.py
@@ -21,7 +21,7 @@ def get_wiggle_data_for_conservation_scores( data_accessor: DataAccessor, panel:
         (data, start, end) = get_bigwig_stats(data_accessor, item, panel.start, panel.end)
     
     # clean & normalize input data range for eard (0..25)
-    overflow_flag = []
+    overflow_flags = []
     normalized_data = []
     scores = []
 
@@ -37,13 +37,13 @@ def get_wiggle_data_for_conservation_scores( data_accessor: DataAccessor, panel:
         x = round((x-data_range[0])*scale)
         unbound_x = x
         x = max(0, min(25, x)) # 0-25
-        overflow_flag.append(1 if x != unbound_x else 0) # outliers flag to grey out
+        overflow_flags.append(1 if x != unbound_x else 0) # outliers flag to grey out
         normalized_data.append(x)
 
     return {
         "normalized_values": data_algorithm("NDZRL", bytearray(normalized_data)),
         "conservation_scores": data_algorithm("SZ", scores),
-        "overflow_flag": data_algorithm("NDZRL", overflow_flag),
+        "overflow_flags": data_algorithm("NDZRL", overflow_flags),
         "range": data_algorithm("NRL", [start+1, end+1])
     }
 

--- a/backend-server/app/data/v16/conservation_scores.py
+++ b/backend-server/app/data/v16/conservation_scores.py
@@ -4,7 +4,7 @@ from command.coremodel import DataHandler, Panel, DataAccessor
 from data.v16.dataalgorithm import data_algorithm
 from model.bigbed import get_bigwig_stats, get_bigwig
 
-def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, data_range: tuple[int,int]=(0,100)) -> dict:
+def get_wiggle_data_for_conservation_scores( data_accessor: DataAccessor, panel: Panel, data_file: str, data_range: tuple[int,int]=(0,100)) -> dict:
     """
     Use the DataAccessor provided to access the wiggle data for a given location.
 
@@ -24,7 +24,6 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
     overflow_flag = []
     normalized_data = []
     scores = []
-    x_x = []
 
     scale = 25/(data_range[1]-data_range[0])
     for i, x in enumerate(data):
@@ -38,7 +37,7 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
         x = round((x-data_range[0])*scale)
         unbound_x = x
         x = max(0, min(25, x)) # 0-25
-        overflow_flag.append(1 if x != unbound_x else 0) # unbounds
+        overflow_flag.append(1 if x != unbound_x else 0) # outliers flag to grey out
         normalized_data.append(x)
 
     return {
@@ -48,26 +47,10 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
         "range": data_algorithm("NRL", [start+1, end+1])
     }
 
-
-class GCWiggleDataHandler(DataHandler):
-    def process_data(self, data_accessor: DataAccessor, panel: Panel, scope, accept: str) -> dict:
-        """
-        Handle a request for GC% wiggle data.
-
-        Args:
-            data_accessor (DataAccessor): The means of accessing data
-            panel (Panel): The panel (ie genomic location, scale) we want
-            scope: extra scope args (e.g. datafile name)
-
-        Returns: A data dict (payload for Response object)
-        """
-
-        return get_wiggle_data(data_accessor, panel, "gc", (0,100))
-    
-class ComparaWiggleDataHandler(DataHandler):
+class ConservationScoresWiggleDataHandler(DataHandler):
     """
         Handle a request for Compara wiggle data (conservation scores).
         Signature as per GCDataHandler.process_data() above.
     """
     def process_data(self, data_accessor: DataAccessor, panel: Panel, scope, accept: str) -> dict:
-        return get_wiggle_data(data_accessor, panel, self.get_datafile(scope), (-10,10))
+        return get_wiggle_data_for_conservation_scores(data_accessor, panel, self.get_datafile(scope), (-10,10))

--- a/backend-server/app/data/v16/gc.py
+++ b/backend-server/app/data/v16/gc.py
@@ -1,0 +1,52 @@
+import math
+
+from command.coremodel import DataHandler, Panel, DataAccessor
+from data.v16.dataalgorithm import data_algorithm
+from model.bigbed import get_bigwig_stats, get_bigwig
+
+def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, data_range: tuple[int,int]=(0,100)) -> dict:
+    """
+    Use the DataAccessor provided to access the wiggle data for a given location.
+
+    Args:
+        data_accessor (DataAccessor): The means of accessing data
+        panel (Panel): The panel (ie genomic location, scale) we want
+        datafile (str): Name of the bigwig data file
+        data_range (tuple[int,int]): The range of values in the data file
+    """
+    item = panel.get_chrom(data_accessor).item_path(data_file)
+    if panel.end - panel.start < 1000:
+        (data, start, end) = get_bigwig(data_accessor, item, panel.start, panel.end)
+    else:
+        (data, start, end) = get_bigwig_stats(data_accessor, item, panel.start, panel.end)
+    
+    # clean & normalize input data range for eard (0..25)
+    scale = 25/(data_range[1]-data_range[0])
+    for i, x in enumerate(data):
+        if x is None or math.isnan(x):
+            x = 0
+        else:
+            x = round((x-data_range[0])*scale)
+            x = max(0, min(25, x))
+        data[i] = x
+
+    return {
+        "values": data_algorithm("NDZRL", bytearray(data)),
+        "range": data_algorithm("NRL", [start, end])
+    }
+
+
+class GCWiggleDataHandler(DataHandler):
+    def process_data(self, data_accessor: DataAccessor, panel: Panel, scope, accept: str) -> dict:
+        """
+        Handle a request for GC% wiggle data.
+
+        Args:
+            data_accessor (DataAccessor): The means of accessing data
+            panel (Panel): The panel (ie genomic location, scale) we want
+            scope: extra scope args (e.g. datafile name)
+
+        Returns: A data dict (payload for Response object)
+        """
+
+        return get_wiggle_data(data_accessor, panel, "gc", (0,100))

--- a/backend-server/app/data/v16/wiggle.py
+++ b/backend-server/app/data/v16/wiggle.py
@@ -29,7 +29,6 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
             x = round((x-data_range[0])*scale)
             x = max(0, min(25, x))
         data[i] = x
-
     return {
         "values": data_algorithm("NDZRL", bytearray(data)),
         "range": data_algorithm("NRL", [start, end])

--- a/backend-server/app/data/v16/wiggle.py
+++ b/backend-server/app/data/v16/wiggle.py
@@ -29,16 +29,17 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
     for i, x in enumerate(data):
         if x is None or math.isnan(x):
             x = 0
-            overflow_flag.append(0)
-            scores.append("{:.2f}".format(x))
-        else:
-            scores.append("{:.2f}".format(x))
-            x = round((x-data_range[0])*scale)
-            unbound_x = x
-            x_x.append(x)
-            x = max(0, min(25, x)) # 0-25
-            overflow_flag.append(1 if x != unbound_x else 0) # unbounds
+
+        # store scores before normalization
+        scores.append("{:.2f}".format(x))
+
+        # normalize x
+        x = round((x-data_range[0])*scale)
+        unbound_x = x
+        x = max(0, min(25, x)) # 0-25
+        overflow_flag.append(1 if x != unbound_x else 0) # unbounds
         normalized_data.append(x)
+
     return {
         "normalized_values": data_algorithm("NDZRL", bytearray(normalized_data)),
         "conservation_scores": data_algorithm("SZ", scores),

--- a/backend-server/app/data/v16/wiggle.py
+++ b/backend-server/app/data/v16/wiggle.py
@@ -21,16 +21,28 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
         (data, start, end) = get_bigwig_stats(data_accessor, item, panel.start, panel.end)
     
     # clean & normalize input data range for eard (0..25)
+    overflow_flag = []
+    normalized_data = []
+    scores = []
+    x_x = []
     scale = 25/(data_range[1]-data_range[0])
     for i, x in enumerate(data):
         if x is None or math.isnan(x):
             x = 0
+            overflow_flag.append(0)
+            scores.append("{:.2f}".format(x))
         else:
+            scores.append("{:.2f}".format(x))
             x = round((x-data_range[0])*scale)
-            x = max(0, min(25, x))
-        data[i] = x
+            unbound_x = x
+            x_x.append(x)
+            x = max(0, min(25, x)) # 0-25
+            overflow_flag.append(1 if x != unbound_x else 0) # unbounds
+        normalized_data.append(x)
     return {
-        "values": data_algorithm("NDZRL", bytearray(data)),
+        "normalized_values": data_algorithm("NDZRL", bytearray(normalized_data)),
+        "conservation_scores": data_algorithm("SZ", scores),
+        "overflow_flag": data_algorithm("NDZRL", overflow_flag),
         "range": data_algorithm("NRL", [start, end])
     }
 

--- a/backend-server/app/data/v16/wiggle.py
+++ b/backend-server/app/data/v16/wiggle.py
@@ -25,6 +25,7 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
     normalized_data = []
     scores = []
     x_x = []
+
     scale = 25/(data_range[1]-data_range[0])
     for i, x in enumerate(data):
         if x is None or math.isnan(x):
@@ -44,7 +45,7 @@ def get_wiggle_data( data_accessor: DataAccessor, panel: Panel, data_file: str, 
         "normalized_values": data_algorithm("NDZRL", bytearray(normalized_data)),
         "conservation_scores": data_algorithm("SZ", scores),
         "overflow_flag": data_algorithm("NDZRL", overflow_flag),
-        "range": data_algorithm("NRL", [start, end])
+        "range": data_algorithm("NRL", [start+1, end+1])
     }
 
 

--- a/backend-server/egs-data/egs/v16/compara/compara-elements.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-elements.eard
@@ -33,8 +33,8 @@ let nw = coord(el.start, [8,...], [0,...]);
 let se = coord(el.end, [16,...], [0,...]);
 rectangle(nw, se, paint, [leaf,...]);
 /* draw zmenu click target boxes */
-let zmenu_paint = constr_element_zmenu(*el);
-rectangle(nw, se, zmenu_paint, [leaf,...]);
+let constr_element_zmenu_paint = constr_element_zmenu(*el);
+rectangle(nw, se, constr_element_zmenu_paint, [leaf,...]);
 
 /* draw track furniture */
 let track_name = setting_string("track_name", []);

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -21,7 +21,7 @@ halt(only_warm());
 /* process data and draw wiggle */
 let normalized_values = data_number(data,"normalized_values");
 let conservation_scores = data_string(data,"conservation_scores");
-let overflow_flag = data_number(data,"overflow_flag");
+let overflow_flags = data_number(data,"overflow_flags");
 let values = normalized_values / 25; //range 0..25=>0..1
 let x_range = data_number(data,"range"); //[start_pos,end_pos]
 let start_pos = index(x_range, 0);
@@ -39,7 +39,10 @@ let is_max = values == 1;
 
 let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
 // arguments: start_pos, end_pos, graph_type, y_values, include_values_bool, target_leaf)
-wiggle(start_pos, end_pos, outlier_graph, values, overflow_flag == 1, leaf);
+wiggle(start_pos, end_pos, outlier_graph, values, overflow_flags == 1, leaf);
+
+let undefined_graph = graph_type(32, "#ffffff"); //graph(height,colour)
+wiggle(start_pos, end_pos, undefined_graph, values, conservation_scores == "0", leaf);
 
 /* Zmenu - Passes scores and positions as arguments */
 

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -19,13 +19,15 @@ let data = get_data(req);
 halt(only_warm());
 
 /* process data and draw wiggle */
-let conservation_scores = data_number(data,"values");
-let values = conservation_scores / 25; //range 0..25=>0..1
+let normalized_values = data_number(data,"normalized_values");
+let conservation_scores = data_string(data,"conservation_scores");
+let overflow_flag = data_number(data,"overflow_flag");
+let values = normalized_values / 25; //range 0..25=>0..1
 let x_range = data_number(data,"range"); //[start_pos,end_pos]
 let start_pos = index(x_range, 0);
 let end_pos = index(x_range, 1);
 
-let outlier_colour = colour!("#B7C0C8"); // grey
+let outlier_colour = colour!("#FF00FF"); // grey
 let normal_colour = colour!("#47d147"); // green
 
 let normal_graph = graph_type(32, normal_colour); //graph(height,colour)
@@ -37,7 +39,7 @@ let is_max = values == 1;
 
 let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
 // arguments: start_pos, end_pos, graph_type, y_values, include_values_bool, target_leaf)
-wiggle(start_pos, end_pos, outlier_graph, values, is_min || is_max, leaf);
+wiggle(start_pos, end_pos, outlier_graph, values, overflow_flag == 1, leaf);
 
 /* Zmenu - Passes scores and positions as arguments */
 

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -64,7 +64,7 @@ let info_leaf = track_leaf(track_id,"main/letter/content");
 draw_track_category(["G"], [track_id], [info_leaf]);
 
 /* draw scales on the left hand side near label "G"*/
-let pen = pen("'Lato', sans-serif",8,[colour!("#666"),...],[colour!("transparent"),...]);
-text(coord([0],[-5],[35]),pen,["+10 "],[info_leaf]); // top scale
-text(coord([0],[12],[35]),pen,["   0 "],[info_leaf]); // middle scale
-text(coord([0],[30],[35]),pen,[" -10 "],[info_leaf]); // bottom scale
+let pen = pen("400 IBM Plex Mono, sans-serif",8,[colour!("#666"),...],[colour!("transparent"),...]);
+text(coord([0],[-5],[35]),pen,["+10"],[info_leaf]); // top scale
+text(coord([0],[12],[35]),pen,[" 0"],[info_leaf]); // middle scale
+text(coord([0],[30],[35]),pen,["-10"],[info_leaf]); // bottom scale

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -41,11 +41,7 @@ let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
 // arguments: start_pos, end_pos, graph_type, y_values, include_values_bool, target_leaf)
 wiggle(start_pos, end_pos, outlier_graph, values, overflow_flags == 1, leaf);
 
-let undefined_graph = graph_type(32, "#ffffff"); //graph(height,colour)
-wiggle(start_pos, end_pos, undefined_graph, values, conservation_scores == "0", leaf);
-
 /* Zmenu - Passes scores and positions as arguments */
-
 // e.g. x_range = [32354272, 32354288]
 // We are creating a list of positions for the score values (using start_pos from x_range and length of values; the content of values is not relevant here).
 let positions = enumerate([len(values)]) + start_pos;

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -36,13 +36,13 @@ let is_min = values == 0;
 let is_max = values == 1;
 
 let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
+// arguments: start_pos, end_pos, graph_type, y_values, include_values_bool, target_leaf)
 wiggle(start_pos, end_pos, outlier_graph, values, is_min || is_max, leaf);
 
 /* Zmenu - Passes scores and positions as arguments */
 
 // e.g. x_range = [32354272, 32354288]
-// We are creating an array of positions from 32354272..32354288 using the enumerate function
-// e.g. values = [8, 8, 15, 13, 9, 10, 11, 11, 11, 13, 11, 14, 12, 8, 12, 14]
+// We are creating a list of positions for the score values (using start_pos from x_range and length of values; the content of values is not relevant here).
 let positions = enumerate([len(values)]) + start_pos;
 
 let conservation_score_zmenu_paint = conservation_score_zmenu(conservation_scores, positions);
@@ -65,6 +65,6 @@ draw_track_category(["G"], [track_id], [info_leaf]);
 
 /* draw scales on the left hand side near label "G"*/
 let pen = pen("'Lato', sans-serif",8,[colour!("#666"),...],[colour!("transparent"),...]);
-text(coord([0],[-5],[35]),pen,["+10 "],[info_leaf]); // position at the top of the track
-text(coord([0],[12],[35]),pen,["   0 "],[info_leaf]); // position at the bottom of the track
-text(coord([0],[30],[35]),pen,[" -10 "],[info_leaf]); // position at the bottom of the track
+text(coord([0],[-5],[35]),pen,["+10 "],[info_leaf]); // top scale
+text(coord([0],[12],[35]),pen,["   0 "],[info_leaf]); // middle scale
+text(coord([0],[30],[35]),pen,[" -10 "],[info_leaf]); // bottom scale

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -21,33 +21,34 @@ halt(only_warm());
 /* process data and draw wiggle */
 let conservation_scores = data_number(data,"values");
 let values = conservation_scores / 25; //range 0..25=>0..1
-let x_range = data_number(data,"range"); //[startpos,endpos]
-
+let x_range = data_number(data,"range"); //[start_pos,end_pos]
+let start_pos = index(x_range, 0);
+let end_pos = index(x_range, 1);
 
 let outlier_colour = colour!("#fc0303"); // red
 let normal_colour = colour!("#47d147"); // green
 
 let normal_graph = graph_type(32, normal_colour); //graph(height,colour)
-// let graph = graph_type(32, colour!("#47d147")); //graph(height,colour)
 let leaf = track_leaf(track_id, "main/main/content");
-wiggle(index(x_range,0), index(x_range,1), normal_graph, values, [true,...], leaf);
+wiggle(start_pos, end_pos, normal_graph, values, [true,...], leaf);
 
 let is_min = values == 0;
 let is_max = values == 1;
 
 let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
-wiggle(index(x_range,0), index(x_range,1), outlier_graph, values, is_min || is_max, leaf);
+wiggle(start_pos, end_pos, outlier_graph, values, is_min || is_max, leaf);
 
 /* Zmenu - Passes scores and positions as arguments */
 
 // e.g. x_range = [32354272, 32354288]
 // We are creating an array of positions from 32354272..32354288 using the enumerate function
 // e.g. values = [8, 8, 15, 13, 9, 10, 11, 11, 11, 13, 11, 14, 12, 8, 12, 14]
-let positions = enumerate([len(values)]) + index(x_range,0);
+let positions = enumerate([len(values)]) + start_pos;
 
 let conservation_score_zmenu_paint = conservation_score_zmenu(conservation_scores, positions);
+// Draw zmenu hotspot boxes (at each position in positions list) with a height of 32px (track height) and width of 1 bp.
 let nw = coord(positions, [0,...], [0,...]);
-let se = coord(positions + 1, [32,...], [0,...]); // Thinking that y=32 as height of the track and x is 1 base pair
+let se = coord(positions + 1, [32,...], [0,...]);
 rectangle(nw, se, conservation_score_zmenu_paint, [leaf,...]);
 
 /* draw horizontal baseline */

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -46,7 +46,7 @@ wiggle(start_pos, end_pos, outlier_graph, values, overflow_flags == 1, leaf);
 // We are creating a list of positions for the score values (using start_pos from x_range and length of values; the content of values is not relevant here).
 let positions = enumerate([len(values)]) + start_pos;
 
-let conservation_score_zmenu_paint = conservation_score_zmenu(conservation_scores, positions);
+let conservation_score_zmenu_paint = conservation_score_zmenu(conservation_scores, positions + 1); // adjusting zmenu position to 1 based
 // Draw zmenu hotspot boxes (at each position in positions list) with a height of 32px (track height) and width of 1 bp.
 let nw = coord(positions, [0,...], [0,...]);
 let se = coord(positions + 1, [32,...], [0,...]);

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -25,7 +25,7 @@ let x_range = data_number(data,"range"); //[start_pos,end_pos]
 let start_pos = index(x_range, 0);
 let end_pos = index(x_range, 1);
 
-let outlier_colour = colour!("#fc0303"); // red
+let outlier_colour = colour!("#B7C0C8"); // grey
 let normal_colour = colour!("#47d147"); // green
 
 let normal_graph = graph_type(32, normal_colour); //graph(height,colour)

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -63,6 +63,7 @@ let info_leaf = track_leaf(track_id,"main/letter/content");
 draw_track_category(["G"], [track_id], [info_leaf]);
 
 /* draw scales on the left hand side near label "G"*/
-let pen = pen("'Lato', sans-serif",10,[colour!("#666"),...],[colour!("transparent"),...]);
-text(coord([0],[-5],[40]),pen,["25"],[info_leaf]); // position at the top of the track
-text(coord([0],[24],[40]),pen,[" 0 "],[info_leaf]); // position at the bottom of the track
+let pen = pen("'Lato', sans-serif",8,[colour!("#666"),...],[colour!("transparent"),...]);
+text(coord([0],[-5],[40]),pen,["10"],[info_leaf]); // position at the top of the track
+text(coord([0],[12],[40]),pen,[" 0 "],[info_leaf]); // position at the bottom of the track
+text(coord([0],[30],[40]),pen,["-10 "],[info_leaf]); // position at the bottom of the track

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -27,7 +27,7 @@ let x_range = data_number(data,"range"); //[start_pos,end_pos]
 let start_pos = index(x_range, 0);
 let end_pos = index(x_range, 1);
 
-let outlier_colour = colour!("#FF00FF"); // grey
+let outlier_colour = colour!("#B7C0C8"); // grey
 let normal_colour = colour!("#47d147"); // green
 
 let normal_graph = graph_type(32, normal_colour); //graph(height,colour)

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -3,6 +3,7 @@ refer "libperegrine";
 refer "libeoe";
 include "../common/track-common.eard";
 include "../common/track-style.eard";
+include "compara-zmenu.eard";
 
 /* setup styles */
 let track_id = setting_string("track_id", []);
@@ -18,11 +19,36 @@ let data = get_data(req);
 halt(only_warm());
 
 /* process data and draw wiggle */
-let values = data_number(data,"values") / 25; //range 0..25=>0..1
+let conservation_scores = data_number(data,"values");
+let values = conservation_scores / 25; //range 0..25=>0..1
 let x_range = data_number(data,"range"); //[startpos,endpos]
-let graph = graph_type(32, colour!("#47d147")); //graph(height,colour)
+
+
+let outlier_colour = colour!("#fc0303"); // red
+let normal_colour = colour!("#47d147"); // green
+
+let normal_graph = graph_type(32, normal_colour); //graph(height,colour)
+// let graph = graph_type(32, colour!("#47d147")); //graph(height,colour)
 let leaf = track_leaf(track_id, "main/main/content");
-wiggle(index(x_range,0), index(x_range,1), graph, values, [true,...], leaf);
+wiggle(index(x_range,0), index(x_range,1), normal_graph, values, [true,...], leaf);
+
+let is_min = values == 0;
+let is_max = values == 1;
+
+let outlier_graph = graph_type(32, outlier_colour); //graph(height,colour)
+wiggle(index(x_range,0), index(x_range,1), outlier_graph, values, is_min || is_max, leaf);
+
+/* Zmenu - Passes scores and positions as arguments */
+
+// e.g. x_range = [32354272, 32354288]
+// We are creating an array of positions from 32354272..32354288 using the enumerate function
+// e.g. values = [8, 8, 15, 13, 9, 10, 11, 11, 11, 13, 11, 14, 12, 8, 12, 14]
+let positions = enumerate([len(values)]) + index(x_range,0);
+
+let conservation_score_zmenu_paint = conservation_score_zmenu(conservation_scores, positions);
+let nw = coord(positions, [0,...], [0,...]);
+let se = coord(positions + 1, [32,...], [0,...]); // Thinking that y=32 as height of the track and x is 1 base pair
+rectangle(nw, se, conservation_score_zmenu_paint, [leaf,...]);
 
 /* draw horizontal baseline */
 let line_paint = paint_hollow(colour!("#d0d0d0"),1);
@@ -32,4 +58,11 @@ rectangle(coord([0],[16],[0]), coord([1],[16],[0]), line_paint, [bg_leaf,...]);
 /* draw track furniture */
 let track_name = setting_string("track_name", []);
 draw_track_name(track_name, "name", track_leaf(track_id,"title/content"));
-draw_track_category(["G"], [track_id], [track_leaf(track_id,"main/letter/content")]);
+
+let info_leaf = track_leaf(track_id,"main/letter/content");
+draw_track_category(["G"], [track_id], [info_leaf]);
+
+/* draw scales on the left hand side near label "G"*/
+let pen = pen("'Lato', sans-serif",10,[colour!("#666"),...],[colour!("transparent"),...]);
+text(coord([0],[-5],[40]),pen,["25"],[info_leaf]); // position at the top of the track
+text(coord([0],[24],[40]),pen,[" 0 "],[info_leaf]); // position at the bottom of the track

--- a/backend-server/egs-data/egs/v16/compara/compara-scores.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-scores.eard
@@ -64,6 +64,6 @@ draw_track_category(["G"], [track_id], [info_leaf]);
 
 /* draw scales on the left hand side near label "G"*/
 let pen = pen("'Lato', sans-serif",8,[colour!("#666"),...],[colour!("transparent"),...]);
-text(coord([0],[-5],[40]),pen,["10"],[info_leaf]); // position at the top of the track
-text(coord([0],[12],[40]),pen,[" 0 "],[info_leaf]); // position at the bottom of the track
-text(coord([0],[30],[40]),pen,["-10 "],[info_leaf]); // position at the bottom of the track
+text(coord([0],[-5],[35]),pen,["+10 "],[info_leaf]); // position at the top of the track
+text(coord([0],[12],[35]),pen,["   0 "],[info_leaf]); // position at the bottom of the track
+text(coord([0],[30],[35]),pen,[" -10 "],[info_leaf]); // position at the bottom of the track

--- a/backend-server/egs-data/egs/v16/compara/compara-zmenu.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-zmenu.eard
@@ -78,3 +78,48 @@ export function constr_element_zmenu(*element) {
   let zmenu_paint = paint_click(zmenu_metadata, zmenu_content, false);
   zmenu_paint //return value
 }
+
+export function conservation_score_zmenu(conservation_scores, positions) {
+
+  struct!(zmenu_metadata,
+    """{
+      "type": "zmenu",
+      "zmenu-type": "conservation-scores"
+    }""");
+  
+  struct!(zmenu_content,
+    """
+    (<0,1>!{
+      "data": [
+        /* First row */
+        [{
+          "items": [
+            { "markup": ["light"], "text": "Position" },
+            { "markup": [], "text": " " },
+            { "markup": ["strong"], "text": <0n> }
+          ],
+          "type": "block"
+        }],
+        /* Second row */
+        [{
+          "items": [
+            {"markup": ["light"], "text": "Conservation score"},
+            {"markup": [], "text": " "},
+            {"markup": ["strong"], "text": <1n>}
+          ],
+          "type": "block"
+        }]
+      ],
+      "metadata": {
+        "position": <0n>,
+        "score": <1n>,
+      }
+    })
+    """,
+    positions,
+    conservation_scores
+  );
+
+  let zmenu_paint = paint_click(zmenu_metadata, zmenu_content, false);
+  zmenu_paint //return value
+}

--- a/backend-server/egs-data/egs/v16/compara/compara-zmenu.eard
+++ b/backend-server/egs-data/egs/v16/compara/compara-zmenu.eard
@@ -105,14 +105,14 @@ export function conservation_score_zmenu(conservation_scores, positions) {
           "items": [
             {"markup": ["light"], "text": "Conservation score"},
             {"markup": [], "text": " "},
-            {"markup": ["strong"], "text": <1n>}
+            {"markup": ["strong"], "text": <1s>}
           ],
           "type": "block"
         }]
       ],
       "metadata": {
         "position": <0n>,
-        "score": <1n>,
+        "score": <1s>,
       }
     })
     """,


### PR DESCRIPTION
### Description
Adds few improvements to conservation scores track

- Adds conservation score values (e.g. a zmenu when cliked on the wiggle track).
- Track scales added
- Markers to indicate values that are outside of the displayed scale - draws the on-limit wiggle line sections red

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2451

### Review App URL(s) 
http://compara-improvements.review.ensembl.org/genome-browser/grch38?focus=gene:ENSG00000221914&location=8:26354997-26442790

Area with outliers http://compara-improvements.review.ensembl.org/genome-browser/grch38?focus=location:1:2891866-2891897&location=1:2891866-2891897

### Knowledge Base
<!--
_If the PR introduces new concept, then provide link(s) to the Knowledge base ( Documentation, Blog etc )_
-->

### Example(s)
<!--
_Any details that will help reviewers to review the PR, such as  (but not limited to ) expected request/response, instruction for viewing the changes via the web client, or any other relevant information._
-->

### Data Availability

<!--
_Is the data required for changes copied to appropriate locaion?_
-->

### Checklist

- [ ] Black formatting
- [ ] Tests

### Dependencies 
<!--
_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
-->
