### PR TITLE
Fix production namespace ( typo )

### DIFF
--- a/backend-server/.backend-server-ci.yml
+++ b/backend-server/.backend-server-ci.yml
@@ -106,7 +106,7 @@ Prod:
     name: production
   variables:
     AGENT: ${PROD_AGENT}
-    NS: ${PROS_NS}
+    NS: ${PROD_NS}
 
 Fallback:
   extends: .deploy_backend


### PR DESCRIPTION
### Description
<!--
_Using one or more sentences, describe the proposed changes and the reason for making them._
-->
Due to typo the production deployment was deploying to default namespace and not production namespace. Fixed typo in the deploy production job. PROS_NS -> PROD_NS
### Related JIRA Issue(s)
<!--_Please provide the URL(s) for any JIRA issues related to this PR._-->
None
### Review App URL(s) 
None

### Knowledge Base
None

### Example(s)

### Data Availability

<!--
_Is the data required for changes copied to appropriate locaion?_
-->

### Checklist

- [ ] Black formatting ( Not needed)
- [ ] Tests

### Dependencies 
<!--
_Does it need anything else before the PR gets merged. May be data update, k8s config update, PR in another repository_
-->
None
