### PR TITLE
Remove expand-variation switch

### DIFF
--- a/backend-server/app/model/expansions.py
+++ b/backend-server/app/model/expansions.py
@@ -70,23 +70,4 @@ class Expansions:
         data = self._get_track_data(track_id)
         if not len(data["datafiles"]):
             raise Exception(f"No datafiles found for track {track_id}")
-        if "settings" not in data:
-            data["settings"] = {}
-        if(list(data["datafiles"].keys())[0].startswith("repeat")): # plug in scales (until Track API is updated)
-            data["settings"]["repeat-details"] = {}
-            data["settings"]["repeat-summary"] = {}
-            data["settings"]["repeat-details"]["scales"] = [1, 8, 2]
-            data["settings"]["repeat-summary"]["scales"] = [9, 100, 4]
-        return self._create_track_set(data)
-
-    # Special case for variation tracks (until migrated to generic expansion track)
-    def register_variation_track(self, track_id: str) -> Tracks:
-        data = self._get_track_data(track_id)
-        # stub for upcoming Track API changes
-        data["datafiles"]["variant-details"] = data["datafiles"].pop("details")
-        data["datafiles"]["variant-summary"] = data["datafiles"].pop("summary")
-        data["settings"] = {}
-        data["settings"]["variant-details"] = {}
-        data["settings"]["variant-details"]["switches"] = ["label-snv-id",
-            "label-snv-alleles", "label-other-id", "label-other-alleles", "show-extents"]
         return self._create_track_set(data)

--- a/backend-server/config/boot-tracks/boot-tracks-16.toml
+++ b/backend-server/config/boot-tracks/boot-tracks-16.toml
@@ -241,19 +241,7 @@ triggers = [["track","contig"]]
 [track.sequence.settings]
 name = ["track","contig","name"]
 
-
-#
-# Expansions
-#
-
-[expansion.variation]
-channel = ["ensembl","main"]
-name = "variation"
-triggers = [
-    ["track","expand-variation"]
-]
-run = "register_variation_track"
-
+# Expansion tracks (variation, repeats etc.)
 [expansion.general]
 channel = ["ensembl","main"]
 name = "general"

--- a/peregrine-ensembl/src/lib.rs
+++ b/peregrine-ensembl/src/lib.rs
@@ -173,8 +173,7 @@ impl GenomeBrowser {
         self.api.switch(&["track","focus","item"],tmpl_true.clone());
         self.api.switch(&["ruler"],tmpl_true.clone());
         self.api.switch(&["ruler","one_based"],tmpl_true.clone());
-        self.api.switch(&["track", "expand-variation"],tmpl_true.clone()); // enable expansion node tracks
-        self.api.switch(&["track", "expand"],tmpl_true.clone());
+        self.api.switch(&["track", "expand"],tmpl_true.clone()); // enable expansion node tracks
         Ok(())
     }
 

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -115,9 +115,8 @@
           let value = !cur;
           tracks_on[track_name] = value;
           let track_path = ["track"];
-          // hack: uuid track id => assume variation track
-          // todo: add this info to GB track list payload
-          if(track_name.length == 36) track_path.push("expand-variation");
+          // hack: uuid track id => assume expansion track
+          if(track_name.length == 36) track_path.push("expand");
           track_path.push(track_name);
           genome_browser.switch(track_path, value);
         }
@@ -159,18 +158,16 @@
         }
 
         function init_variant_track(track_id) { //enable expansion (variant) tracks
-          genome_browser.switch(["track", "expand-variation"], true);
-          genome_browser.switch(["track", "expand-variation", track_id], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "name"], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "label-snv-id"], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "label-snv-alleles"], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "label-other-id"], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "label-other-alleles"], true);
-          genome_browser.switch(["track", "expand-variation", track_id, "show-extents"], true);
+          genome_browser.switch(["track", "expand", track_id], true);
+          genome_browser.switch(["track", "expand", track_id, "name"], true);
+          genome_browser.switch(["track", "expand", track_id, "label-snv-id"], true);
+          genome_browser.switch(["track", "expand", track_id, "label-snv-alleles"], true);
+          genome_browser.switch(["track", "expand", track_id, "label-other-id"], true);
+          genome_browser.switch(["track", "expand", track_id, "label-other-alleles"], true);
+          genome_browser.switch(["track", "expand", track_id, "show-extents"], true);
         }
 
         function init_expansion_track(track_id) {
-          genome_browser.switch(["track", "expand"], true);
           genome_browser.switch(["track", "expand", track_id], true);
           genome_browser.switch(["track", "expand", track_id, "name"], true);
           genome_browser.switch(["track", "expand", track_id, "label"], true);

--- a/peregrine-generic/src/lib.rs
+++ b/peregrine-generic/src/lib.rs
@@ -162,8 +162,7 @@ impl GenomeBrowser {
         self.api.switch(&["track","focus","item"],tmpl_true.clone());
         self.api.switch(&["ruler"],tmpl_true.clone());
         self.api.switch(&["ruler","one_based"],tmpl_true.clone());
-        self.api.switch(&["track", "expand-variation"],tmpl_true.clone()); // enable expansion node tracks
-        self.api.switch(&["track", "expand"],tmpl_true.clone());
+        self.api.switch(&["track", "expand"],tmpl_true.clone()); // enable expansion node tracks
         self.api.switch(&["buttons"],tmpl_true.clone());
         self.api.switch(&["buttons","gene"],tmpl_true.clone());
         self.api.switch(&["buttons","gene","expand"],tmpl_true.clone());


### PR DESCRIPTION
### Description
The updates in [this PR](https://github.com/Ensembl/ensembl-web-track-api/pull/28) add a `settings` field to Track API payloads, allowing to remove the `expand-variation` switch and its  hardcoded values from Genome Browser code (variation tracks now use the general `expand` switch and the associated `register_track` function)

### Related JIRA Issue(s)
https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2741

### Review App URL(s) 
http://migrate-expansion.review.ensembl.org

### Dependencies 
Track API endpoint with the updated datamodel and tracks from [this PR](https://github.com/Ensembl/ensembl-web-track-api/pull/28) (currently available on dev-2020).
