### PR TITLE
Fix zoomed-in track issue

### DIFF
--- a/backend-server/app/model/expansions.py
+++ b/backend-server/app/model/expansions.py
@@ -56,9 +56,9 @@ class Expansions:
             # use default track scales (min, max, step) if not defined in Track API
             if "scales" not in data["settings"][program]:
                 if program.endswith("summary"):
-                    data["settings"][program]["scales"] = [5, 100, 4]
+                    data["settings"][program]["scales"] = [6, 100, 4]
                 elif program.endswith("details"):
-                    data["settings"][program]["scales"] = [1, 4, 1]
+                    data["settings"][program]["scales"] = [1, 5, 1]
                 else:
                     data["settings"][program]["scales"] = [0, 100, 3]
             track = self._create_track(data, program)
@@ -69,5 +69,5 @@ class Expansions:
     def register_track(self, track_id: str) -> Tracks:
         data = self._get_track_data(track_id)
         if not len(data["datafiles"]):
-            raise Exception(f"No datafiles found for track {track_id}")
+            raise Exception(f"No datafiles defined for track {track_id}")
         return self._create_track_set(data)

--- a/backend-server/app/model/expansions.py
+++ b/backend-server/app/model/expansions.py
@@ -58,7 +58,7 @@ class Expansions:
                 if program.endswith("summary"):
                     data["settings"][program]["scales"] = [6, 100, 4]
                 elif program.endswith("details"):
-                    data["settings"][program]["scales"] = [1, 5, 1]
+                    data["settings"][program]["scales"] = [3, 5, 1]
                 else:
                     data["settings"][program]["scales"] = [0, 100, 3]
             track = self._create_track(data, program)

--- a/backend-server/egs-data/egs/v16/variant/focus-variant.eard
+++ b/backend-server/egs-data/egs/v16/variant/focus-variant.eard
@@ -86,6 +86,8 @@ let (focus_genome_id,focus_variant_id) = focus_variant_settings();
 let req = request("self()", "variant-details");
 scope(req, "datafile", "variant-details.bb");
 let data = get_data(req);
+halt(only_warm());
+
 let v.chromosome = data_string(data,"chromosome");
 let v.start = data_number(data,"start");
 let v.end = v.start + data_number(data,"length");
@@ -98,8 +100,6 @@ let v.consequence = data_string(data,"consequence"); //['upstream_gene_variant',
 let deep = v.variety != "SNV";
 let has_anchor_bp = v.variety == "deletion" || v.variety == "indel";
 let v.display_start = if(has_anchor_bp, v.start+1, v.start);
-
-halt(only_warm());
 
 /* Setup leafs */
 

--- a/backend-server/egs-data/egs/v16/variant/variant-details.eard
+++ b/backend-server/egs-data/egs/v16/variant/variant-details.eard
@@ -178,8 +178,6 @@ let deep = v.variety != "SNV";
 let has_anchor_bp = v.variety == "deletion" || v.variety == "indel";
 let v.display_start = if(has_anchor_bp, v.start+1, v.start);
 
-halt(only_warm());
-
 /* ZMenu data */
 
 let zmenu_paint = variant_zmenu(*v);

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -157,20 +157,19 @@
           });
         }
 
-        function init_variant_track(track_id) { //enable expansion (variant) tracks
+        function init_expansion_track(track_id) {
           genome_browser.switch(["track", "expand", track_id], true);
           genome_browser.switch(["track", "expand", track_id, "name"], true);
+          genome_browser.switch(["track", "expand", track_id, "label"], true);
+        }
+
+        function init_variant_track(track_id) { //turn on all variant track switches
+          init_expansion_track(track_id);
           genome_browser.switch(["track", "expand", track_id, "label-snv-id"], true);
           genome_browser.switch(["track", "expand", track_id, "label-snv-alleles"], true);
           genome_browser.switch(["track", "expand", track_id, "label-other-id"], true);
           genome_browser.switch(["track", "expand", track_id, "label-other-alleles"], true);
           genome_browser.switch(["track", "expand", track_id, "show-extents"], true);
-        }
-
-        function init_expansion_track(track_id) {
-          genome_browser.switch(["track", "expand", track_id], true);
-          genome_browser.switch(["track", "expand", track_id, "name"], true);
-          genome_browser.switch(["track", "expand", track_id, "label"], true);
         }
 
         function flipper(path) {
@@ -386,11 +385,11 @@
         /* Set initial tracks/settings */
         genome_browser.switch(["ruler"], true);
         genome_browser.switch(["ruler", "one_based"], true);
-        init_tracks(["gene-pc-fwd","contig","gc","focus"]);
+        init_tracks(["gene-pc-fwd","contig","gc","focus"]); //remove tracks for faster sandbox
         genome_browser.switch(["settings","tab-selected"],"G");
 
         //Human
-        //init_variant_track("0adabdbc-e0a5-487d-a712-98e6127712f2");
+        init_variant_track("9ae6b320-851f-4512-9547-a78f0b2d1148"); //variants track in dev-2020
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: location
         //genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");


### PR DESCRIPTION
### Description
This PR addresses an issue when some tracks (e.g. variation, simple features) did not switch from the summary view to the detailed track view when zoomed in.

**Background:**
The root cause of the issue is hard to pin down (since there are no errors or and the code runs as expected), but it seems that in this case the zoomed-in view did not render because the third (`step`) element of the track scales parameter (`scale=[min_zoom_level,max_zoom_level,step]`) for the zoomed-out view was the same than `max_zoom_level` of the zoomed-in view (4). Therefore the zoomed-out view remained still in view (did not re-render to zoomed-in view) when the zoom level was in the zoomed-in bracket (1-4). The issue can be fixed by either decreasing the scale `step` param for zoom-out view or (as I did in this PR) increasing the zoom thresholds between the zoom-in/out views (the step param needs to be smaller than the min/max zoom bracket).

### Related JIRA Issue(s)
[ENSWBSITES-2746](https://www.ebi.ac.uk/panda/jira/browse/ENSWBSITES-2746)

### Review App URL(s) 
http://fix-zoom.review.ensembl.org

### Knowledge Base
NA

### Example(s)
Zoom in to a variation track, confirm it switches to the detailed view (individual variant blocks shown).


### Checklist

- [x] Black formatting
- [x] Tests (sandbox)

### Dependencies 
* Updated graphql core service name in dev in order to fix review app ([MR here](https://gitlab.ebi.ac.uk/ensembl-web/ensembl-k8s-manifests/-/merge_requests/42))
* The review app uses latest genome browser npm package version in client-side ([PR here](https://github.com/Ensembl/ensembl-client/pull/1167))
