### PR TITLE
Add switch for disabling track padding

### DIFF
--- a/backend-server/config/boot-tracks/tracks-include.toml
+++ b/backend-server/config/boot-tracks/tracks-include.toml
@@ -4,3 +4,4 @@ program_version = 1
 
 [include.general.settings]
 tab-selected = ["settings","tab-selected"]
+no-padding = ["settings","no-padding"]

--- a/backend-server/config/sources-s3.toml
+++ b/backend-server/config/sources-s3.toml
@@ -1,8 +1,8 @@
 [source.apple]
 driver = "s3"
 url = "http://ensembl-2020-gb-flatfiles.s3.eu-west-2.amazonaws.com/"
-refget_url = "https://dev-2020.ensembl.org/api/refget/sequence/"
-metadata_url = "https://dev-2020.ensembl.org/api/metadata/"
+refget_url = "https://staging-2020.ensembl.org/api/refget/sequence/"
+metadata_url = "https://staging-2020.ensembl.org/api/metadata/"
 
 min_version = 16
 

--- a/backend-server/egs-data/egs/v16/common/track-common.eard
+++ b/backend-server/egs-data/egs/v16/common/track-common.eard
@@ -45,6 +45,9 @@ export procedure draw_track_category(category,track_ids,leafs) {
 
     let count = len(leafs);
     let enough_zeros = repeat(0,count);
+    // Don't draw categories when no space for it (track padding disabled)
+    let no_padding = setting_boolean("no-padding",[]);
+    let leafs = if(no_padding,repeat(leaf(""),count),leafs);
 
     /* Draw the label itself */
     let pen = pen("'Lato', sans-serif",cat_text_size,[cat_text_colour,...],[colour!("transparent"),...]);

--- a/backend-server/egs-data/egs/v16/gene/gene-common-visual.eard
+++ b/backend-server/egs-data/egs/v16/gene/gene-common-visual.eard
@@ -92,10 +92,11 @@ export procedure draw_focus_track_chevrons(strand,*leaf) {
 }
 
 export procedure draw_sidebar_chevrons(*leaf) {
-    image(coord([0],[0],[24]),["chevron-dark-left",...],[index(leaf.letter,0),...]);
-    image(coord([0],[0],[24]),["chevron-dark-left",...],[index(leaf.letter,1),...]);
-    image(coord([0],[0],[24]),["chevron-dark-right",...],[index(leaf.letter,2),...]);
-    image(coord([0],[0],[24]),["chevron-dark-right",...],[index(leaf.letter,3),...]);
+    let no_padding = setting_boolean("no-padding",[]);
+    image(coord([0],[0],[24]),["chevron-dark-left",...],if(no_padding,[leaf(""),...],[index(leaf.letter,0),...]));
+    image(coord([0],[0],[24]),["chevron-dark-left",...],if(no_padding,[leaf(""),...],[index(leaf.letter,1),...]));
+    image(coord([0],[0],[24]),["chevron-dark-right",...],if(no_padding,[leaf(""),...],[index(leaf.letter,2),...]));
+    image(coord([0],[0],[24]),["chevron-dark-right",...],if(no_padding,[leaf(""),...],[index(leaf.letter,3),...]));
 }
 
 export procedure draw_focus_sidebar_chevrons(strand,*leaf) {

--- a/backend-server/egs-data/egs/v16/other/framing.eard
+++ b/backend-server/egs-data/egs/v16/other/framing.eard
@@ -2,8 +2,9 @@ program "ensembl-webteam/core" "framing" 1;
 refer "libperegrine";
 refer "libeoe";
 
-let pad_left = leaf("pad-left/content");
-let pad_right = leaf("pad-right/content");
+let no_padding = setting_boolean("no-padding", []);
+let pad_left = if(no_padding, leaf(""), leaf("pad-left/content")); 
+let pad_right = if(no_padding, leaf(""), leaf("pad-right/content"));
 
 style!("""
     pad-left/ {

--- a/backend-server/egs-data/egs/v16/other/ruler.eard
+++ b/backend-server/egs-data/egs/v16/other/ruler.eard
@@ -80,14 +80,15 @@ rectangle(coord([0],[0],[0]),coord([1],[16],[0]),bgd_paint,[ruler_under_leaf,...
 rectangle(coord([0],[-1],[0]),coord([1],[-16],[0]),bgd_paint,[ruler_under_leaf,...]);
 
 /* Draw fiddly bp rectangle */
+let no_padding = setting_boolean("no-padding",[]); // no space for it when padding disabled
 /* ... top ruler */
-rectangle(coord([0],[0],[48]),coord([0],[16],[48]),paint,[ruler_over_leaf,...]); // sep, vert
-rectangle(coord([0],[16],[0]),coord([0],[16],[48]),paint,[ruler_over_leaf,...]); // sep, horiz
-text(coord([0],[2],[4]),pen,["bp"],[ruler_over_leaf]);
+rectangle(coord([0],[0],[48]),coord([0],[16],[48]),paint,if(no_padding,[leaf(""),...],[ruler_over_leaf,...])); // sep, vert
+rectangle(coord([0],[16],[0]),coord([0],[16],[48]),paint,if(no_padding,[leaf(""),...],[ruler_over_leaf,...])); // sep, horiz
+text(coord([0],[2],[4]),pen,["bp"],if(no_padding,[leaf(""),...],[ruler_over_leaf]));
 /* ... bottom ruler */
-rectangle(coord([0],[-1],[48]),coord([0],[-16],[48]),paint,[ruler_over_leaf,...]); // sep, vert
-rectangle(coord([0],[-16],[0]),coord([0],[-16],[48]),paint,[ruler_over_leaf,...]); // sep, horiz
-text(coord([0],[-14],[4]),pen,["bp"],[ruler_over_leaf]);
+rectangle(coord([0],[-1],[48]),coord([0],[-16],[48]),paint,if(no_padding,[leaf(""),...],[ruler_over_leaf,...])); // sep, vert
+rectangle(coord([0],[-16],[0]),coord([0],[-16],[48]),paint,if(no_padding,[leaf(""),...],[ruler_over_leaf,...])); // sep, horiz
+text(coord([0],[-14],[4]),pen,["bp"],if(no_padding,[leaf(""),...],[ruler_over_leaf]));
 
 /* Draw numbers */
 text(coord(markings,[2,...],[4,...]),pen,numbers,[ruler_bp_leaf,...]);

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -385,7 +385,7 @@
         /* Set initial tracks/settings */
         genome_browser.switch(["ruler"], true);
         genome_browser.switch(["ruler", "one_based"], true);
-        //genome_browser.switch(["track", "no-left-padding"], true);
+        //genome_browser.switch(["settings", "no-padding"], true); //disable left/right side margins
         init_tracks(["gene-pc-fwd","regulation","focus"]);
         genome_browser.switch(["settings","tab-selected"],"G");
 
@@ -393,7 +393,7 @@
         //Check track ID: curl "https://staging-2020.ensembl.org/api/tracks/track_categories/a7335667-93e7-11ec-a39d-005056b38ce3"
         // | jq -r '.track_categories[].track_list[] | select(.label == "dbSNP short variants") | .track_id'
         //Check datafiles: https://eu-west-2.console.aws.amazon.com/s3/buckets/ensembl-2020-gb-flatfiles?prefix=a7335667-93e7-11ec-a39d-005056b38ce3%2F
-        //init_expansion_track("d3c13017-9f70-4d64-87a2-51cb20f042d4"); //variation track
+        //init_expansion_track("d3c13017-9f70-4d64-87a2-51cb20f042d4"); //variation track (update track ID)
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: location
         //genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -385,22 +385,23 @@
         /* Set initial tracks/settings */
         genome_browser.switch(["ruler"], true);
         genome_browser.switch(["ruler", "one_based"], true);
-        init_tracks(["gene-pc-fwd","gc","regulation","focus"]);
+        genome_browser.switch(["track", "no-left-padding"], true);
+        init_tracks(["gene-pc-fwd","regulation","focus"]);
         genome_browser.switch(["settings","tab-selected"],"G");
 
         //Human
         //Check track ID: curl "https://staging-2020.ensembl.org/api/tracks/track_categories/a7335667-93e7-11ec-a39d-005056b38ce3"
         // | jq -r '.track_categories[].track_list[] | select(.label == "dbSNP short variants") | .track_id'
         //Check datafiles: https://eu-west-2.console.aws.amazon.com/s3/buckets/ensembl-2020-gb-flatfiles?prefix=a7335667-93e7-11ec-a39d-005056b38ce3%2F
-        init_expansion_track("d3c13017-9f70-4d64-87a2-51cb20f042d4"); //variation track
+        //init_expansion_track("d3c13017-9f70-4d64-87a2-51cb20f042d4"); //variation track
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: location
-        //genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
-        //genome_browser.goto(159980000,160000500);
+        genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
+        genome_browser.goto(159980000,160000500);
         //goto: variant
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: gene
-        genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618"); //BRCA2
+        //genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618"); //BRCA2
 
         //Pig
         //init_expansion_track("83090e95-2586-451c-bf3c-8ffc50068e2b"); //repeats

--- a/peregrine-generic/index.html
+++ b/peregrine-generic/index.html
@@ -385,7 +385,7 @@
         /* Set initial tracks/settings */
         genome_browser.switch(["ruler"], true);
         genome_browser.switch(["ruler", "one_based"], true);
-        genome_browser.switch(["track", "no-left-padding"], true);
+        //genome_browser.switch(["track", "no-left-padding"], true);
         init_tracks(["gene-pc-fwd","regulation","focus"]);
         genome_browser.switch(["settings","tab-selected"],"G");
 
@@ -396,12 +396,12 @@
         //init_expansion_track("d3c13017-9f70-4d64-87a2-51cb20f042d4"); //variation track
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: location
-        genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
-        genome_browser.goto(159980000,160000500);
+        //genome_browser.set_stick("a7335667-93e7-11ec-a39d-005056b38ce3:13");
+        //genome_browser.goto(159980000,160000500);
         //goto: variant
         //jump_variant("rs1557469781", 1, 1176408);
         //goto: gene
-        //genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618"); //BRCA2
+        genome_browser.jump("focus:gene:a7335667-93e7-11ec-a39d-005056b38ce3:ENSG00000139618"); //BRCA2
 
         //Pig
         //init_expansion_track("83090e95-2586-451c-bf3c-8ffc50068e2b"); //repeats


### PR DESCRIPTION
### Description
This PR adds a global setting (switch) for Genome Browser to toggle vertical padding (left/right side margin) for all tracks.
This change is implemented for upcoming structural variation alignments view, but is also useful for other Genome Browser integrations where the tracks are expected to span the whole width of the tracks viewport.

This setting disables:
* left/right side padding boxes in the tracks wrapper (framing.eard)
* elements that use the (left side) padding space: track category letter, chevron, ruler "bp" text

### Related JIRA Issue(s)
Done as part of SV alignments work: https://embl.atlassian.net/browse/ENSWBSITES-2941

### Review App URL(s)
http://sv-tracks.review.ensembl.org

The padding can be switched with the new toggle under gene track settings cog.
<img width="319" height="185" alt="padding-toggle" src="https://github.com/user-attachments/assets/1583ee00-fc5a-49bf-acfd-1ed606af6193" />

**Note:** This toggle is a temporary change in ensembl-client for this review app 
(related: do NOT merge sv-tracks branch in ensembl-client repo).
