### PR TITLE
SV gene track: tidy up gene labels

### DIFF
--- a/backend-server/egs-data/egs/v16/gene/sv-gene.eard
+++ b/backend-server/egs-data/egs/v16/gene/sv-gene.eard
@@ -22,7 +22,7 @@ let *leafs = sv_gene_leafs(*gene);
 let paint = paint_solid(colour!("#279afc"));
 rectangle(coord(gene.start,[0,...],[-0.5,...]), coord(gene.end,[5,...],[0.5,...]), paint, leafs.blocks);
 let pen = pen("'IBM Plex Mono', sans-serif", 10, [colour!("#6f8190"),...], [colour!("transparent"),...]);
-running_text(coord(gene.start, [8,...], [0,...]), coord(gene.end,[8,...],[0,...]), pen, gene.name, leafs.text);
+running_text(coord(gene.start, [8,...], [0,...]), coord(gene.end,[8,...],[0,...]), pen, gene.name, if(len(gene.start)<100, leafs.blocks, [leaf(""),...]));
 
 /* Draw strand divider line */
 let line_paint = paint_dotted([colour!("white"),...],[colour!("#999"),...],4,1,0.5);

--- a/backend-server/egs-data/egs/v16/gene/sv-transcript.eard
+++ b/backend-server/egs-data/egs/v16/gene/sv-transcript.eard
@@ -57,7 +57,7 @@ rectangle(coord(thick_exon.start,[2,...],[0,...]), coord(thick_exon.end,[8,...],
 
 /* Draw gene labels */
 let pen = pen("'IBM Plex Mono', sans-serif", 10, [colour!("#6f8190"),...], [colour!("transparent"),...]);
-running_text(coord(tr_gene.start,[11,...],[0,...]), coord(tr_gene.end,[11,...],[0,...]), pen, tr_gene.name, leafs.text);
+running_text(coord(tr_gene.start,[11,...],[0,...]), coord(tr_gene.end,[11,...],[0,...]), pen, tr_gene.name, if(len(gene.start)<100, leafs.under_leaf, [leaf(""),...]));
 
 /* Draw strand divider line */
 let bg_leaf = leaf("tracks/track/sv-gene/main/main/line/background/content");


### PR DESCRIPTION
### Description

This PR attempts to address the issue of messy/overlapping gene labels in the structural variants app gene track when it gets too crowded.

### Review App URL(s) 
http://update-sv-gene.review.ensembl.org
