### PR TITLE
SV: fix gene labels overlap

### DIFF
--- a/backend-server/egs-data/egs/v16/gene/sv-common.eard
+++ b/backend-server/egs-data/egs/v16/gene/sv-common.eard
@@ -39,7 +39,6 @@ export procedure sv_gene_styles() {
     }
 
     tracks/track/sv-gene/main/main/**/text/ {
-      bump-width: none;
       system: tracking-special;
     }
 """);


### PR DESCRIPTION
### Description
This (meta)PR attempts to address the issue of messy/overlapping gene labels in the structural variants app gene track. There are several approaches, each with its own drawbacks, which I've listed below. 
Click on the links to try out the review apps and vote for the one to get merged (including combos like 3+5).

1. [Stack the labels](http://sv-gene-label-3.review.ensembl.org/structural-variants?ref-genome-id=a7335667-93e7-11ec-a39d-005056b38ce3&ref-location=11:63567132-67950684&alt-genome-id=4c07817b-c7c5-463f-8624-982286bc4355) ([diff](https://github.com/Ensembl/ensembl-dauphin-style-compiler/compare/master...sv-gene-label-3)). Drawback: takes more vertical space, genes may overlap.
2. [Stack both genes and labels](http://sv-gene-label-1.review.ensembl.org/structural-variants?ref-genome-id=a7335667-93e7-11ec-a39d-005056b38ce3&ref-location=11:63567132-67950684&alt-genome-id=4c07817b-c7c5-463f-8624-982286bc4355) ([diff](https://github.com/Ensembl/ensembl-dauphin-style-compiler/compare/master...sv-gene-label-1)). Drawback: takes even more vertical space.
3. [Decrease zoom threshold](http://sv-gene-label-2.review.ensembl.org/structural-variants?ref-genome-id=a7335667-93e7-11ec-a39d-005056b38ce3&ref-location=11:63567132-67950684&alt-genome-id=4c07817b-c7c5-463f-8624-982286bc4355) ([diff](https://github.com/Ensembl/ensembl-dauphin-style-compiler/compare/master...sv-gene-label-2)). Drawback: more zooming in to see labels (which can still overlap).
4. [Hide labels in dense areas](http://sv-gene-label-4.review.ensembl.org/structural-variants?ref-genome-id=a7335667-93e7-11ec-a39d-005056b38ce3&ref-location=11:63567132-67950684&alt-genome-id=4c07817b-c7c5-463f-8624-982286bc4355) ([diff](https://github.com/Ensembl/ensembl-dauphin-style-compiler/compare/master...sv-gene-label-4)). Drawback: hides too many labels.
5. [Make gene labels opaque](http://sv-gene-label-5.review.ensembl.org/structural-variants?ref-genome-id=a7335667-93e7-11ec-a39d-005056b38ce3&ref-location=11:63567132-67950684&alt-genome-id=4c07817b-c7c5-463f-8624-982286bc4355) ([diff](https://github.com/Ensembl/ensembl-dauphin-style-compiler/compare/master...sv-gene-label-5)). Drawback: chops off most labels in dense areas.
