### PR TITLE
Migrate focus gene resolver from NCD to Thoas

### DIFF
--- a/backend-server/app/data/focusjump.py
+++ b/backend-server/app/data/focusjump.py
@@ -1,6 +1,4 @@
-from model.species import Species
 from command.coremodel import DataAccessor
-from ncd import NCDRead
 from model.graphql import CoreApiClient
 from model.version import Version
 
@@ -12,13 +10,7 @@ class FocusJumpHandler:
         data_accessor ():
     """
     def __init__(self):
-        self._ncd_files = {}
         self._core_api = CoreApiClient()
-
-    def _ensure_ncd(self, data_accessor: DataAccessor, sp_obj: Species):
-        if sp_obj.genome_id not in self._ncd_files:
-            accessor = data_accessor.resolver.get(sp_obj.item_path("jump"))
-            self._ncd_files[sp_obj.genome_id] = NCDRead(accessor.ncd())
 
     def get(self, data_accessor: DataAccessor, lookup: str, version: Version):
         """
@@ -39,22 +31,15 @@ class FocusJumpHandler:
             if cached is not None:
                 return cached
 
-            # focus transcripts are resolved via core API.
             if focus_type == "transcript":
                 (stick, start, end) = self._core_api.get_transcript_location((genome_id, object_id))
-                if stick is not None:
-                    out = (stick, start, end)
-                    data_accessor.cache.set_jump(lookup, *out, version)
-                    return out
+            elif focus_type == "gene":
+                (stick, start, end) = self._core_api.get_gene_location((genome_id, object_id))
+            else:
                 return None
-            
-            # focus genes are indexed in NCD files
-            sp_obj = data_accessor.data_model.species(genome_id)
-            self._ensure_ncd(data_accessor, sp_obj)
-            value = self._ncd_files[sp_obj.genome_id].get(lookup.encode("utf-8"))
-            if value is not None:
-                parts = value.decode("utf-8").split("\t")
-                out = (sp_obj.genome_id + ":" + parts[0], int(float(parts[1])), int(float(parts[2])))
+
+            if stick is not None and start is not None and end is not None:
+                out = (stick, start, end)
                 data_accessor.cache.set_jump(lookup, *out, version)
                 return out
         return None

--- a/backend-server/app/data/v16/gene/genedata.py
+++ b/backend-server/app/data/v16/gene/genedata.py
@@ -1,13 +1,10 @@
 import os.path
 
-from ncd import NCDRead
-
 from command.coremodel import DataHandler, Panel, DataAccessor
 from data.v16.dataalgorithm import data_algorithm
 from data.v16.gene.transcriptfilter import filter_lines_by_criteria, lines_for_transcript_id
 from data.v16.gene.transcriptorder import sort_data_by_transcript_priority
 from model.bigbed import get_bigbed
-from model.datalocator import AccessItem
 from model.graphql import CoreApiClient
 from model.transcriptfile import TranscriptFileLine
 from tangle.tangle import TangleFactory
@@ -55,28 +52,15 @@ TANGLE_OVERVIEW_WITH_IDS = TANGLE_FACTORY.make_from_tomlfile(OV_TANGLE_PATH,["id
 
 CORE_API = CoreApiClient()
 
-def get_approx_location(data_accessor: DataAccessor, genome_id: str, id: str):
-    species = data_accessor.data_model.species(genome_id)
-    if species != None:
-        accessor = data_accessor.resolver.get(AccessItem("jump",genome_id))
-        jump_ncd = NCDRead(accessor.ncd())
-        key = "focus:gene:{}:{}".format(genome_id, id)
-        value = jump_ncd.get(key.encode("utf-8"))
-        if value != None:
-            parts = value.decode('utf-8').split("\t")
-            if len(parts) == 3:
-                on_stick = "{}:{}".format(genome_id,parts[0])
-                return (on_stick, max(0,int(parts[1])), int(parts[2]))
-    return (None,None,None)
-
 # We need to return all the data for the focus gene wherever we are (except for the sequence) as
 # transcript configuration, ordering, etc is still relevant.
 def update_panel_from_id(data_accessor: DataAccessor, panel: Panel, for_id: tuple[str,str,str]):
-    # Fetch focus transcript location from Core API, use NCD file for focus genes
     if for_id[2] == 'transcript':
         (stick, start, end) = CORE_API.get_transcript_location((for_id[0], for_id[1]))
+    elif for_id[2] == 'gene':
+        (stick, start, end) = CORE_API.get_gene_location((for_id[0], for_id[1]))
     else:
-        (stick, start, end) = get_approx_location(data_accessor,for_id[0],for_id[1])
+        (stick, start, end) = (None, None, None)
     if stick is not None:
         panel.stick = stick
         panel.start = start

--- a/backend-server/app/model/graphql.py
+++ b/backend-server/app/model/graphql.py
@@ -27,6 +27,22 @@ query TranscriptLocation($genomeId: String!, $transcriptId: String!) {
   }
 }
 """
+
+    _GENE_LOCATION_QUERY = """
+query GeneLocation($genomeId: String!, $geneId: String!) {
+    gene(by_id: { genome_id: $genomeId, stable_id: $geneId }) {
+        slice {
+            region {
+                name
+            }
+            location {
+                start
+                end
+            }
+        }
+    }
+}
+"""
     
     def __init__(self):
         self._core_api_url = self._read_toml()
@@ -36,20 +52,44 @@ query TranscriptLocation($genomeId: String!, $transcriptId: String!) {
             toml_file = toml.loads(f.read())
         return toml_file.get("apis", {}).get("core_api", None)
 
-    def get_transcript_location(
-        self, for_id: tuple[str,str]
+    def _extract_location(
+        self, genome_id: str, feature: dict
     ) -> tuple[str, int, int] | tuple[None, None, None]:
-
         empty_location = (None, None, None)
-        (genome_id, transcript_id) = for_id
+
+        slc = feature.get("slice", {})
+        region_name = slc.get("region", {}).get("name")
+        start = slc.get("location", {}).get("start")
+        end = slc.get("location", {}).get("end")
+
+        if region_name is None or start is None or end is None:
+            return empty_location
+
+        # Add padding around the feature for viewport postitioning.
+        padding = (end - start) / 2
+        start -= padding
+        end += padding
+        stick = f"{genome_id}:{region_name}"
+        return (stick, max(0, int(start)), int(end))
+
+    def _get_feature_location(
+        self,
+        genome_id: str,
+        feature_id: str,
+        feature_type: str,
+        variable_name: str,
+        query: str,
+    ) -> tuple[str, int, int] | tuple[None, None, None]:
+        empty_location = (None, None, None)
+
         if not self._core_api_url:
             return empty_location
 
         payload: dict[str, str | dict[str, str]] = {
-            "query": self._TRANSCRIPT_LOCATION_QUERY,
+            "query": query,
             "variables": {
                 "genomeId": genome_id,
-                "transcriptId": transcript_id,
+                variable_name: feature_id,
             },
         }
 
@@ -59,8 +99,9 @@ query TranscriptLocation($genomeId: String!, $transcriptId: String!) {
             body = response.json()
         except Exception as e:
             logger.warning(
-                "Core API transcript lookup failed for '%s' (%s): %s",
-                transcript_id,
+                "Core API %s lookup failed for '%s' (%s): %s",
+                feature_type,
+                feature_id,
                 genome_id,
                 e,
             )
@@ -68,27 +109,39 @@ query TranscriptLocation($genomeId: String!, $transcriptId: String!) {
 
         if body.get("errors"):
             logger.warning(
-                "Core API transcript lookup returned GraphQL errors for '%s': %s",
-                transcript_id,
+                "Core API %s lookup returned GraphQL errors for '%s': %s",
+                feature_type,
+                feature_id,
                 body.get("errors"),
             )
             return empty_location
 
-        transcript = body.get("data", {}).get("transcript")
-        if not transcript:
+        feature = body.get("data", {}).get(feature_type)
+        if not feature:
             return empty_location
 
-        slc = transcript.get("slice", {})
-        region_name = slc.get("region", {}).get("name")
-        start = slc.get("location", {}).get("start")
-        end = slc.get("location", {}).get("end")
+        return self._extract_location(genome_id, feature)
 
-        if region_name is None or start is None or end is None:
-            return empty_location
+    def get_transcript_location(
+        self, for_id: tuple[str,str]
+    ) -> tuple[str, int, int] | tuple[None, None, None]:
+        (genome_id, transcript_id) = for_id
+        return self._get_feature_location(
+            genome_id,
+            transcript_id,
+            "transcript",
+            "transcriptId",
+            self._TRANSCRIPT_LOCATION_QUERY,
+        )
 
-        # add padding around the transcript (for the viewport; same as in NCD file)
-        padding = (end-start)/2
-        start -= padding
-        end += padding
-        stick = f"{genome_id}:{region_name}"
-        return (stick, max(0,int(start)), int(end))
+    def get_gene_location(
+        self, for_id: tuple[str, str]
+    ) -> tuple[str, int, int] | tuple[None, None, None]:
+        (genome_id, gene_id) = for_id
+        return self._get_feature_location(
+            genome_id,
+            gene_id,
+            "gene",
+            "geneId",
+            self._GENE_LOCATION_QUERY,
+        )


### PR DESCRIPTION
### Description
Use Thoas backend service instead of NCD files for fetching gene coordinates (as we already do for focus transcripts).

### Related JIRA Issue(s)
[ENSWBSITES-3019](https://embl.atlassian.net/browse/ENSWBSITES-3019)

### Review App URL(s) 
http://no-ncd.review.ensembl.org