### PR TITLE
Allow ":" in focus IDs

### DIFF
--- a/backend-server/app/data/focusjump.py
+++ b/backend-server/app/data/focusjump.py
@@ -23,8 +23,8 @@ class FocusJumpHandler:
         Returns:
 
         """
-        if lookup.startswith('focus:') and lookup.count(':') == 3:
-            (_, focus_type, genome_id, object_id) = lookup.split(':')
+        if lookup.startswith('focus:') and lookup.count(':') > 2:
+            (_, focus_type, genome_id, object_id) = lookup.split(':', 3)
 
             # check cache first
             cached = data_accessor.cache.get_jump(lookup,version)


### PR DESCRIPTION
### Description
This PR fixes a bug where GB did not find focus objects (genes/transcripts) with `:` in its ID.

### Related JIRA Issue(s)
[ENSWBSITES-3021](https://embl.atlassian.net/browse/ENSWBSITES-3021)

### Review App URL(s) 
https://fix-focus-gene-id.review.ensembl.org

### Example(s)
https://fix-focus-gene-id.review.ensembl.org/genome-browser/GCA_000011145.1?focus=transcript:ENSB:Ll1CT-f4ze8uSZe